### PR TITLE
fix: Resolve YAML syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dp32 release/
 
         # Create README for plugins
-        @"
+        $readmeContent = @"
 # x64dbg MCP Plugin
 
 Pre-built plugins for x64dbg dynamic analysis integration.
@@ -103,13 +103,17 @@ Pre-built plugins for x64dbg dynamic analysis integration.
 
 ## Version
 
-Built from: ${{ github.ref_name }}
-Commit: ${{ github.sha }}
-"@ | Out-File -FilePath release/README.md -Encoding UTF8
+Built from: $env:GITHUB_REF_NAME
+Commit: $env:GITHUB_SHA
+"@
+        $readmeContent | Out-File -FilePath release/README.md -Encoding UTF8
 
         Write-Host "Artifacts prepared in release/"
         Get-ChildItem release/
       shell: pwsh
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        GITHUB_SHA: ${{ github.sha }}
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes YAML syntax error on line 90 of `.github/workflows/release.yml` that was causing workflow validation to fail.

## Changes Made

- Fixed PowerShell here-string syntax in the "Prepare Release Artifacts" step
- Moved here-string content to a variable before piping to `Out-File`
- Changed GitHub Actions expressions to PowerShell environment variables
- Added `env` section to pass `github.ref_name` and `github.sha` as environment variables

## Technical Details

**Problem:**
The YAML parser was confused by GitHub Actions expressions (`${{ github.ref_name }}`) embedded directly in a PowerShell here-string, causing a syntax error.

**Solution:**
```powershell
# Before (broken):
@"
Built from: ${{ github.ref_name }}
"@ | Out-File ...

# After (fixed):
$readmeContent = @"
Built from: $env:GITHUB_REF_NAME
"@
$readmeContent | Out-File ...
```

Then pass values via environment variables in the step's `env` section.

## Testing

- [x] YAML validation should pass on this PR
- [ ] Workflow will be tested on next release tag

## Related Issues

None - fixes workflow configuration error discovered during repository setup.
