### PR TITLE
fix: Correct SDK path using absolute path with GITHUB_WORKSPACE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,14 @@ jobs:
       shell: pwsh
       run: |
         Write-Host "Building 64-bit plugin..."
+        $sdkPath = "$env:GITHUB_WORKSPACE/extern/x64dbg_sdk"
         cd src/engines/dynamic/x64dbg/plugin
 
         New-Item -ItemType Directory -Force -Path build-x64
         cd build-x64
 
         cmake .. -G "Visual Studio 17 2022" -A x64 `
-          -DX64DBG_SDK_PATH="$PWD/../../../../../extern/x64dbg_sdk" `
+          -DX64DBG_SDK_PATH="$sdkPath" `
           -DCMAKE_BUILD_TYPE=Release
 
         cmake --build . --config Release
@@ -71,13 +72,14 @@ jobs:
       shell: pwsh
       run: |
         Write-Host "Building 32-bit plugin..."
+        $sdkPath = "$env:GITHUB_WORKSPACE/extern/x64dbg_sdk"
         cd src/engines/dynamic/x64dbg/plugin
 
         New-Item -ItemType Directory -Force -Path build-x32
         cd build-x32
 
         cmake .. -G "Visual Studio 17 2022" -A Win32 `
-          -DX64DBG_SDK_PATH="$PWD/../../../../../extern/x64dbg_sdk" `
+          -DX64DBG_SDK_PATH="$sdkPath" `
           -DCMAKE_BUILD_TYPE=Release
 
         cmake --build . --config Release


### PR DESCRIPTION
## Summary

Fixes the CMake SDK path calculation error that caused the build to fail.

## Problem

The previous relative path was off by one level:
- From `build-x64` directory: `src/engines/dynamic/x64dbg/plugin/build-x64`
- Path used: `$PWD/../../../../../extern/x64dbg_sdk`
- Resolved to: `src/extern/x64dbg_sdk` ❌
- Should be: `extern/x64dbg_sdk` ✅

CMake error:
```
x64dbg SDK not found at D:/a/binary-mcp/binary-mcp/src/extern/x64dbg_sdk
error C1083: Cannot open include file: 'pluginsdk/_plugins.h'
```

## Solution

Use absolute path via `$env:GITHUB_WORKSPACE`:
```powershell
$sdkPath = "$env:GITHUB_WORKSPACE/extern/x64dbg_sdk"
cmake .. -DX64DBG_SDK_PATH="$sdkPath"
```

## Benefits

✅ No relative path calculation errors
✅ Clear and explicit path
✅ Works regardless of build directory depth
✅ Easier to understand and maintain

## Testing

- [ ] Will be tested with v0.0.6-test tag

## Related

- Fixes failure in v0.0.5-test run
- Follows successful SDK download from PR #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)