### PR TITLE
fix: Correct CMake include path to match plugin source includes

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(x64dbg_mcp SHARED ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
 
 # Include directories
 target_include_directories(x64dbg_mcp PRIVATE
-    ${X64DBG_SDK_PATH}/pluginsdk
+    ${X64DBG_SDK_PATH}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
## Summary

Fixes the compiler error where it couldn't find `pluginsdk/_plugins.h`.

## Problem

There was a mismatch between how the plugin code includes headers vs how CMake sets up include directories:

**Plugin code** (`plugin.cpp:1`):
```cpp
#include "pluginsdk/_plugins.h"
```

**CMakeLists.txt** (line 36):
```cmake
target_include_directories(x64dbg_mcp PRIVATE
    ${X64DBG_SDK_PATH}/pluginsdk  ❌
```

This caused the compiler to look for:
```
${X64DBG_SDK_PATH}/pluginsdk/pluginsdk/_plugins.h
```

But the file is actually at:
```
${X64DBG_SDK_PATH}/pluginsdk/_plugins.h
```

**Compiler error**:
```
error C1083: Cannot open include file: 'pluginsdk/_plugins.h': No such file or directory
```

## Solution

Change the include directory to point to `${X64DBG_SDK_PATH}` without the `/pluginsdk` suffix:

```cmake
target_include_directories(x64dbg_mcp PRIVATE
    ${X64DBG_SDK_PATH}  ✅
```

Now when the compiler sees `#include "pluginsdk/_plugins.h"`, it correctly resolves to:
```
${X64DBG_SDK_PATH}/pluginsdk/_plugins.h  ✅
```

## Benefits

✅ Matches how the source code includes headers  
✅ Aligns with how ScyllaHide and other x64dbg plugins structure includes  
✅ Simple one-line fix  

## Testing

- [ ] Will be tested with v0.0.7-test tag

## Related

- Fixes compiler error in v0.0.6-test run
- Completes the SDK setup started in PR #8 and PR #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)