### PR TITLE
fix: Add x64dbg SDK includes to plugin.h to define types

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -1,5 +1,3 @@
-#include "pluginsdk/_plugins.h"
-#include "pluginsdk/_scriptapi.h"
 #include "plugin.h"
 #include "http_server.h"
 #include "commands.h"

--- a/src/engines/dynamic/x64dbg/plugin/plugin.h
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "pluginsdk/_plugins.h"
+#include "pluginsdk/_scriptapi.h"
+
 #define PLUGIN_NAME "x64dbg_mcp"
 #define PLUGIN_VERSION 1
 #define PLUGIN_VERSION_STR "0.1.0"


### PR DESCRIPTION
## Summary

Fixes compilation errors by ensuring x64dbg SDK types are defined before use in plugin.h.

## Problem

The `plugin.h` header file declares variables and functions using x64dbg SDK types like:
- `HWND` (Windows handle)
- `PLUG_INITSTRUCT` (x64dbg plugin init structure)

But it didn't include the SDK headers that define these types.

This worked in `plugin.cpp` because it included the SDK headers first:
```cpp
#include "pluginsdk/_plugins.h"  // Defines types
#include "plugin.h"  // Now types are known ✅
```

But failed in other source files that included `plugin.h` directly:
```cpp
#include "plugin.h"  // HWND is undefined ❌
```

**Compilation errors**:
```
plugin.h(9,8): error C4430: missing type specifier - int assumed
plugin.h(16,17): error C2065: 'PLUG_INITSTRUCT': undeclared identifier
```

## Solution

Move the SDK includes to `plugin.h` so types are always defined:

```cpp
#pragma once

#include "pluginsdk/_plugins.h"
#include "pluginsdk/_scriptapi.h"

// Now all SDK types are available
extern HWND g_hwndDlg;
bool pluginInit(PLUG_INITSTRUCT* initStruct);
```

## Benefits

✅ Types are defined before use in all compilation units  
✅ Follows standard C++ header practice  
✅ Matches pattern used by other x64dbg plugins  
✅ Eliminates duplicate includes in source files  

## Testing

- [ ] Will be tested with v0.0.8-test tag

## Related

- Fixes compilation errors discovered in v0.0.7-test
- Completes the plugin build setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)