### PR TITLE
fix: Include winsock2 before Windows headers to avoid conflicts

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/http_server.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/http_server.cpp
@@ -1,7 +1,5 @@
 #include "http_server.h"
 #include "plugin.h"
-#include <winsock2.h>
-#include <ws2tcpip.h>
 #include <sstream>
 #include <algorithm>
 

--- a/src/engines/dynamic/x64dbg/plugin/plugin.h
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Include winsock2 before Windows headers to avoid conflicts
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
 #include "pluginsdk/_plugins.h"
 #include "pluginsdk/_scriptapi.h"
 


### PR DESCRIPTION
## Summary

Fixes Windows socket header redefinition errors by ensuring correct include order.

## Problem

When compiling the plugin, we encountered socket redefinition errors:

```
error C2011: 'sockaddr': 'struct' type redefinition
warning C4005: 'AF_IPX': macro redefinition
warning C4005: 'AF_MAX': macro redefinition
```

**Root cause**: Classic Windows header include order issue.

1. `plugin.h` includes x64dbg SDK headers
2. x64dbg SDK headers include `<windows.h>`
3. `<windows.h>` includes old winsock definitions
4. Later, `http_server.cpp` tries to include `<winsock2.h>`
5. But it's too late - old winsock is already defined → conflict

## Solution

Ensure `<winsock2.h>` is included BEFORE any Windows headers:

```cpp
#pragma once

// Include winsock2 BEFORE Windows headers
#define WIN32_LEAN_AND_MEAN  // Minimize Windows headers
#include <winsock2.h>
#include <ws2tcpip.h>

// Now safe to include SDK headers (which include windows.h)
#include "pluginsdk/_plugins.h"
#include "pluginsdk/_scriptapi.h"
```

## Changes

1. Added `WIN32_LEAN_AND_MEAN` define to minimize Windows header bloat
2. Moved winsock2 includes to `plugin.h` before SDK headers
3. Removed duplicate winsock2 includes from `http_server.cpp`

## Benefits

✅ Ensures correct include order across all compilation units  
✅ Follows Windows programming best practices  
✅ Matches pattern used by other x64dbg plugins  
✅ Prevents socket API conflicts  

## Testing

- [ ] Will be tested with v0.0.9-test tag

## Related

- Fixes socket redefinition errors in v0.0.8-test
- Final piece for successful plugin compilation