### PR TITLE
fix: Replace WIN32_LEAN_AND_MEAN with _WINSOCKAPI_ to preserve SDK functionality

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/plugin.h
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.h
@@ -1,7 +1,8 @@
 #pragma once
 
-// Include winsock2 before Windows headers to avoid conflicts
-#define WIN32_LEAN_AND_MEAN
+// Prevent old winsock from being included by windows.h
+#define _WINSOCKAPI_
+// Include winsock2 before Windows headers
 #include <winsock2.h>
 #include <ws2tcpip.h>
 


### PR DESCRIPTION
## Summary

Fixes x64dbg Script API namespace errors by using a more targeted approach to prevent winsock conflicts.

## Problem

After fixing the winsock redefinition errors with WIN32_LEAN_AND_MEAN, we encountered new errors:

```
error C2871: 'Script': a namespace with this name does not exist
error C2653: 'Debug': is not a class or namespace name  
error C2653: 'Register': is not a class or namespace name
```

**Root cause**: `WIN32_LEAN_AND_MEAN` was too aggressive. It strips out large portions of the Windows headers to reduce compile times, but the x64dbg SDK Script API requires full Windows functionality to work properly.

## Solution

Use `_WINSOCKAPI_` instead of `WIN32_LEAN_AND_MEAN`:

```cpp
// Prevent old winsock from being included by windows.h
#define _WINSOCKAPI_
// Include winsock2 before Windows headers
#include <winsock2.h>
#include <ws2tcpip.h>
```

**Difference**:
- `WIN32_LEAN_AND_MEAN`: Excludes many Windows APIs (crypto, DDE, RPC, Shell, Winsock, etc.) ❌
- `_WINSOCKAPI_`: Only prevents old winsock.h, keeps everything else ✅

## Benefits

✅ Prevents old winsock conflicts (original goal)  
✅ Preserves full Windows API for SDK  
✅ Allows Script API namespaces to be defined  
✅ More surgical, less disruptive fix  

## Testing

- [ ] Will be tested with v0.0.10-test tag

## Related

- Fixes Script API namespace errors from v0.0.9-test
- Refines the winsock conflict solution from PR #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)