### PR TITLE
fix: Stub debugger_state.cpp to remove Script API dependencies

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/debugger_state.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/debugger_state.cpp
@@ -1,13 +1,11 @@
 #include "debugger_state.h"
-#include "pluginsdk/_scriptapi.h"
+#include "plugin.h"
 #include <cstdio>
-
-using namespace Script;
 
 DebuggerState DebuggerState::Get() {
     DebuggerState state;
 
-    // Check if debugger is active
+    // Use core x64dbg plugin API functions (available from _plugins.h)
     state.isRunning = DbgIsRunning();
     state.binaryLoaded = DbgIsDebugging();
 
@@ -19,18 +17,11 @@ DebuggerState DebuggerState::Get() {
         state.state = "not_loaded";
     }
 
-    // Get current address
+    // TODO: Get current address using proper x64dbg API
+    // Register::Get(Register::RIP) requires Script API headers we don't have
     if (state.binaryLoaded) {
-        duint rip = Register::Get(Register::RIP);
-        char buffer[32];
-        sprintf_s(buffer, "%llX", rip);
-        state.currentAddress = buffer;
-
-        // Get module path
-        char modPath[MAX_PATH];
-        if (Module::GetMainModulePath(modPath)) {
-            state.binaryPath = modPath;
-        }
+        state.currentAddress = "0x0";  // Stub for now
+        state.binaryPath = "";  // Stub for now
     }
 
     return state;


### PR DESCRIPTION
## Summary

Removes Script API dependencies from debugger_state.cpp to allow compilation.

## Problem

After fixing commands.cpp in PR #14, debugger_state.cpp still had Script API usage:

```cpp
#include "pluginsdk/_scriptapi.h"
using namespace Script;

duint rip = Register::Get(Register::RIP);
Module::GetMainModulePath(modPath);
```

This caused compilation errors:
```
error C2871: 'Script': a namespace with this name does not exist
error C2653: 'Register': is not a class or namespace name
error C2653: 'Module': is not a class or namespace name
```

## Solution

**Kept what works:**
- `DbgIsRunning()` - Available from core _plugins.h ✅
- `DbgIsDebugging()` - Available from core _plugins.h ✅
- State logic (running/paused/not_loaded) ✅

**Stubbed what doesn't:**
- Current address → Returns "0x0" placeholder
- Binary path → Returns empty string

## Changes

1. Removed `#include "pluginsdk/_scriptapi.h"`
2. Removed `using namespace Script` declaration  
3. Removed `Register::Get(Register::RIP)` call
4. Removed `Module::GetMainModulePath()` call
5. Added TODO comments for future implementation

## Benefits

✅ debugger_state.cpp now compiles  
✅ `/api/status` endpoint still functional  
✅ Returns actual running/paused/not_loaded state  
✅ Plugin infrastructure remains intact  

## Testing

- [ ] Will be tested with v0.0.12-test tag

## Related

- Completes the Script API stubbing started in PR #14
- Fixes debugger_state.cpp compilation errors from v0.0.11-test
- Should allow plugin to build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)