### PR TITLE
fix: Correct plugin file extensions from .dp64/.dp32 to .dpx64/.dpx32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,8 @@ jobs:
         Write-Host "Preparing release artifacts..."
         New-Item -ItemType Directory -Force -Path release
 
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dp64 release/
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dp32 release/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dpx64 release/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dpx32 release/
 
         Write-Host "Artifacts prepared in release/"
         Get-ChildItem release/


### PR DESCRIPTION
## Summary

Fixes the "Prepare Release Artifacts" step by using the correct plugin file extensions.

## Problem

**Great news**: Both x64 and x32 plugins built successfully in v0.0.14-test! ✅

But the "Prepare Release Artifacts" step failed:

```
Cannot find path 'x64dbg_mcp.dp64' because it does not exist.
```

## Root Cause

CMakeLists.txt sets the plugin file extension as:
```cmake
set_target_properties(x64dbg_mcp PROPERTIES
    SUFFIX ".dp${PLUGIN_ARCH}"  # PLUGIN_ARCH = "x64" or "x32"
)
```

This produces:
- ✅ `x64dbg_mcp.dpx64` (actual file created)
- ✅ `x64dbg_mcp.dpx32` (actual file created)

But the workflow was looking for:
- ❌ `x64dbg_mcp.dp64` (doesn't exist)
- ❌ `x64dbg_mcp.dp32` (doesn't exist)

## Solution

Update workflow to use correct file extensions:

```yaml
Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dpx64 release/
Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dpx32 release/
```

## Benefits

✅ Matches actual build output  
✅ Simple 2-line fix  
✅ No code changes needed  
✅ Plugins are already building successfully  

## Testing

- [ ] Will be tested with v0.0.15-test tag
- [ ] Should successfully create release with both plugin files
- [ ] This should complete the entire build workflow!

## Related

- Fixes artifact preparation failure from v0.0.14-test
- Both plugins built successfully, just needed correct file names
- **This is the final fix - plugins are ready!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)