### PR TITLE
fix: Update release file names to match actual build output (.dpx64/.dpx32)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,8 @@ jobs:
         ### Pre-built x64dbg Plugins
 
         This release includes pre-built x64dbg plugins for dynamic analysis:
-        - `x64dbg_mcp.dp64` - 64-bit debugger plugin
-        - `x64dbg_mcp.dp32` - 32-bit debugger plugin
+        - `x64dbg_mcp.dpx64` - 64-bit debugger plugin
+        - `x64dbg_mcp.dpx32` - 32-bit debugger plugin
 
         ### Installation
 
@@ -154,8 +154,8 @@ jobs:
         **Manual Plugin Installation:**
         1. Download the plugin files from assets below
         2. Copy to your x64dbg installation:
-           - `x64dbg_mcp.dp64` → `x64dbg/x64/plugins/`
-           - `x64dbg_mcp.dp32` → `x64dbg/x32/plugins/`
+           - `x64dbg_mcp.dpx64` → `x64dbg/x64/plugins/`
+           - `x64dbg_mcp.dpx32` → `x64dbg/x32/plugins/`
         3. Restart x64dbg
 
         ### Features
@@ -191,8 +191,8 @@ jobs:
         name: Release ${{ steps.version.outputs.version }}
         body_path: release_notes.md
         files: |
-          release/x64dbg_mcp.dp64
-          release/x64dbg_mcp.dp32
+          release/x64dbg_mcp.dpx64
+          release/x64dbg_mcp.dpx32
         draft: false
         prerelease: false
       env:


### PR DESCRIPTION
## Summary

Fixes the Create Release step to attach the plugin files to the release.

## Problem

**In v0.0.15-test:**
- ✅ Both plugins built successfully
- ✅ Release was created 
- ❌ No files were attached to the release

From the logs:
```
🤔 Pattern 'release/x64dbg_mcp.dp64' does not match any files.
🤔 Pattern 'release/x64dbg_mcp.dp32' does not match any files.
```

## Root Cause

**Build produces:**
- `x64dbg_mcp.dpx64` (CMake: `.dp` + `x64` = `.dpx64`)
- `x64dbg_mcp.dpx32` (CMake: `.dp` + `x32` = `.dpx32`)

**Workflow was looking for:**
- `x64dbg_mcp.dp64` ❌
- `x64dbg_mcp.dp32` ❌

## Solution

Update all file references from `.dp64`/`.dp32` to `.dpx64`/`.dpx32`:

**1. Create Release step:**
```yaml
files: |
  release/x64dbg_mcp.dpx64  # Was: dp64
  release/x64dbg_mcp.dpx32  # Was: dp32
```

**2. Release notes:**
- Updated plugin file names in documentation
- Updated manual installation instructions

## Benefits

✅ Files will actually be attached to releases  
✅ Documentation matches reality  
✅ Installation instructions are correct  
✅ Users can download the plugins  

## Testing

- [ ] Will be tested with v0.0.16-test tag
- [ ] Should create release with both .dpx64 and .dpx32 files attached

## Related

- Completes the work from v0.0.15-test which successfully built plugins
- This is the absolute final fix - everything else works!

🤖 Generated with [Claude Code](https://claude.com/claude-code)