### PR TITLE
fix: Use functools.wraps to preserve function signatures in decorator

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,7 @@ Provides 30+ tools for static and dynamic binary analysis:
 - Dynamic analysis via x64dbg (native plugin)
 """
 
+import functools
 import json
 import logging
 import re
@@ -48,6 +49,7 @@ def log_to_session(func):
     Transparently captures tool name, arguments, and output without
     affecting tool behavior.
     """
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Call the original function
         result = func(*args, **kwargs)
@@ -66,9 +68,6 @@ def log_to_session(func):
 
         return result
 
-    # Preserve original function metadata
-    wrapper.__name__ = func.__name__
-    wrapper.__doc__ = func.__doc__
     return wrapper
 
 


### PR DESCRIPTION
## Problem

The MCP server was crashing on startup with:
```
ValueError: Functions with *args are not supported as tools
```

**Root Cause:** The `log_to_session` decorator was wrapping analysis tool functions with a wrapper that used `*args, **kwargs`. When FastMCP tried to inspect the decorated functions to register them as tools, it saw the wrapper's signature (with `*args`) instead of the original function's signature, and rejected them.

## Solution

Use `@functools.wraps(func)` on the wrapper function. This decorator properly preserves the original function's metadata, including the `__signature__` attribute that FastMCP uses for inspection.

## Changes

```diff
+import functools

 def log_to_session(func):
-    def wrapper(*args, **kwargs):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
         ...
-    wrapper.__name__ = func.__name__
-    wrapper.__doc__ = func.__doc__
     return wrapper
```

## Verification

**Before fix:**
```python
inspect.signature(wrapper)
# Returns: (*args, **kwargs)  ❌ FastMCP rejects this
```

**After fix:**
```python
inspect.signature(decorated_func)
# Returns: (binary_path: str, force_reanalyze: bool = False) -> str  ✅
```

**Testing:**
- ✅ Function signature preserved correctly
- ✅ No `*args` visible in inspected signature
- ✅ Ruff linting passes
- ✅ All metadata preserved (`__name__`, `__doc__`, `__signature__`)

## Impact

Fixes server crash on Windows (and all platforms). All 22 analysis tools can now be properly registered with FastMCP.

---

**Affected tools:** All 14 analysis tools with `@log_to_session` decorator:
- analyze_binary
- get_functions
- get_imports
- get_strings
- get_xrefs
- decompile_function
- get_call_graph
- find_api_calls
- get_memory_map
- extract_metadata
- search_bytes
- detect_crypto
- generate_iocs
- list_data_types