### PR TITLE
Fix: Use correct Ghidra loader class names in documentation

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -84,7 +84,7 @@ def get_analysis_context(
         binary_path: Path to binary file
         force_reanalyze: Force re-analysis even if cached
         processor: Optional processor specification (e.g., "x86:LE:64:default")
-        loader: Optional loader specification (e.g., "Portable Executable (PE)")
+        loader: Optional loader name (e.g., "PeLoader" for Windows PE, "ElfLoader" for Linux ELF)
 
     Returns:
         Analysis context dict
@@ -184,15 +184,18 @@ def analyze_binary(
         binary_path: Path to the binary file to analyze
         force_reanalyze: Force re-analysis even if cached (default: False)
         processor: Optional processor spec when AutoImporter fails (e.g., "x86:LE:64:default")
-        loader: Optional loader spec when AutoImporter fails (e.g., "Portable Executable (PE)")
+        loader: Optional loader name when AutoImporter fails (e.g., "PeLoader" for Windows PE)
 
     Returns:
         Analysis summary with basic statistics
 
     Note:
         If Ghidra's AutoImporter fails with "No load spec found", you can manually specify:
-        - For x86-64 Windows PE: processor="x86:LE:64:default", loader="Portable Executable (PE)"
-        - For x86-64 Linux ELF: processor="x86:LE:64:default", loader="Executable and Linking Format (ELF)"
+        - For x86-64 Windows PE: processor="x86:LE:64:default", loader="PeLoader"
+        - For x86-64 Linux ELF: processor="x86:LE:64:default", loader="ElfLoader"
+        - For macOS Mach-O: processor="x86:LE:64:default", loader="MachoLoader"
+
+        Common Ghidra loaders: PeLoader, ElfLoader, MachoLoader, BinaryLoader, CoffLoader
     """
     try:
         context = get_analysis_context(binary_path, force_reanalyze, processor, loader)


### PR DESCRIPTION
## Summary
Fixed documentation to use correct Ghidra loader class names. Ghidra's headless analyzer requires full loader class names, not abbreviations or long-form display names.

## Problem Evolution
1. **Initial issue**: Used long-form names like `"Portable Executable (PE)"` 
   - Error: `Invalid loader name specified: -overwrite`
   - Ghidra couldn't parse and misinterpreted next argument

2. **First fix attempt**: Used short-form abbreviations like `"PE"`
   - Error: `Invalid loader name specified: PE`
   - Ghidra rejected abbreviations

3. **Root cause**: Ghidra requires actual loader class names

## Solution
Updated documentation to use Ghidra loader class names:
- ❌ `loader="Portable Executable (PE)"` (long-form display name)
- ❌ `loader="PE"` (abbreviation)
- ✅ `loader="PeLoader"` (actual Ghidra class name)

## Correct Loader Names
Based on Ghidra's built-in loaders:
- **PeLoader** - Windows PE/COFF executables
- **ElfLoader** - Linux ELF executables
- **MachoLoader** - macOS Mach-O executables
- **BinaryLoader** - Raw binary files
- **CoffLoader** - COFF object files
- And others (see Ghidra documentation)

## Changes
- `get_analysis_context()`: Updated loader parameter docs with correct class names
- `analyze_binary()`: Updated examples and added list of common loaders

## Testing
Users can now successfully analyze binaries that fail AutoImporter:
```python
analyze_binary(
    "path/to/binary",
    processor="x86:LE:64:default",
    loader="PeLoader"  # Correct Ghidra class name
)
```