### PR TITLE
feat: Package releases as single zip with source and plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,13 +90,13 @@ jobs:
       shell: pwsh
       run: |
         Write-Host "Preparing release artifacts..."
-        New-Item -ItemType Directory -Force -Path release
+        New-Item -ItemType Directory -Force -Path release/x64dbg-plugins
 
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dpx64 release/
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dpx32 release/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dpx64 release/x64dbg-plugins/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dpx32 release/x64dbg-plugins/
 
-        Write-Host "Artifacts prepared in release/"
-        Get-ChildItem release/
+        Write-Host "Artifacts prepared in release/x64dbg-plugins/"
+        Get-ChildItem release/x64dbg-plugins/
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
@@ -129,20 +129,67 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Version: $VERSION"
 
+    - name: Create Release Package
+      run: |
+        echo "Creating release package structure..."
+
+        # Create package directory with version name
+        PACKAGE_NAME="binary-mcp-${{ steps.version.outputs.version }}"
+        mkdir -p "$PACKAGE_NAME"
+
+        # Copy source code (excluding unnecessary files)
+        rsync -av --progress \
+          --exclude='.git' \
+          --exclude='.github' \
+          --exclude='__pycache__' \
+          --exclude='*.pyc' \
+          --exclude='.pytest_cache' \
+          --exclude='.venv' \
+          --exclude='node_modules' \
+          --exclude='.DS_Store' \
+          --exclude='*.swp' \
+          --exclude='.claude' \
+          . "$PACKAGE_NAME/"
+
+        # Copy x64dbg plugins to dedicated directory
+        mkdir -p "$PACKAGE_NAME/x64dbg-plugins"
+        cp release/x64dbg_mcp.dpx64 "$PACKAGE_NAME/x64dbg-plugins/"
+        cp release/x64dbg_mcp.dpx32 "$PACKAGE_NAME/x64dbg-plugins/"
+
+        # Create installation instructions for plugins
+        cat > "$PACKAGE_NAME/x64dbg-plugins/README.md" << 'EOF'
+        # x64dbg Plugin Installation
+
+        Copy the plugin files to your x64dbg installation:
+
+        - `x64dbg_mcp.dpx64` → `x64dbg/x64/plugins/`
+        - `x64dbg_mcp.dpx32` → `x64dbg/x32/plugins/`
+
+        Then restart x64dbg.
+        EOF
+
+        # Create the release zip
+        zip -r "${PACKAGE_NAME}.zip" "$PACKAGE_NAME"
+
+        echo "Release package created: ${PACKAGE_NAME}.zip"
+        ls -lh "${PACKAGE_NAME}.zip"
+
     - name: Create Release Notes
       run: |
         cat > release_notes.md << 'NOTES_EOF'
         ## Binary MCP Server Release
 
-        ### Pre-built x64dbg Plugins
+        ### Complete Package
 
-        This release includes pre-built x64dbg plugins for dynamic analysis:
-        - `x64dbg_mcp.dpx64` - 64-bit debugger plugin
-        - `x64dbg_mcp.dpx32` - 32-bit debugger plugin
+        This release includes everything you need:
+        - **MCP Server source code** - Full binary analysis server
+        - **Pre-built x64dbg plugins** - Ready-to-use debugger plugins in `x64dbg-plugins/` directory
+          - `x64dbg_mcp.dpx64` - 64-bit debugger plugin
+          - `x64dbg_mcp.dpx32` - 32-bit debugger plugin
 
         ### Installation
 
-        **Quick Install:**
+        **Option 1: Quick Install (Recommended)**
         ```bash
         # Windows
         irm https://raw.githubusercontent.com/Sarks0/binary-mcp/main/install.ps1 | iex
@@ -151,12 +198,10 @@ jobs:
         curl -fsSL https://raw.githubusercontent.com/Sarks0/binary-mcp/main/install.py | python3 -
         ```
 
-        **Manual Plugin Installation:**
-        1. Download the plugin files from assets below
-        2. Copy to your x64dbg installation:
-           - `x64dbg_mcp.dpx64` → `x64dbg/x64/plugins/`
-           - `x64dbg_mcp.dpx32` → `x64dbg/x32/plugins/`
-        3. Restart x64dbg
+        **Option 2: Manual Installation**
+        1. Download and extract `binary-mcp-${{ steps.version.outputs.version }}.zip`
+        2. Follow instructions in `INSTALL.md`
+        3. For x64dbg plugins, see `x64dbg-plugins/README.md`
 
         ### Features
 
@@ -177,7 +222,7 @@ jobs:
         - Python 3.12+
         - Java 21+ (for Ghidra)
         - Ghidra (auto-detected or set GHIDRA_HOME)
-        - x64dbg (optional, for dynamic analysis)
+        - x64dbg (optional, for dynamic analysis on Windows)
 
         ### Documentation
 
@@ -191,8 +236,7 @@ jobs:
         name: Release ${{ steps.version.outputs.version }}
         body_path: release_notes.md
         files: |
-          release/x64dbg_mcp.dpx64
-          release/x64dbg_mcp.dpx32
+          binary-mcp-${{ steps.version.outputs.version }}.zip
         draft: false
         prerelease: false
       env:


### PR DESCRIPTION
Restructure release workflow to create a single comprehensive package containing both the MCP server source code and pre-built x64dbg plugins.

Changes:
- Single zip file: binary-mcp-{version}.zip
- Organized structure with dedicated x64dbg-plugins/ directory
- Auto-generated plugin installation README
- Excludes unnecessary files (.git, .github, __pycache__, .venv, .claude)
- Version number in filename for clarity

Benefits:
- Simpler for users - one download instead of multiple files
- Clear organization with plugins in dedicated folder
- Complete package includes everything needed
- Cleaner release assets page

Release structure:
binary-mcp-v1.0.0/
├── src/              # MCP server source
├── x64dbg-plugins/   # Pre-built debugger plugins
│   ├── x64dbg_mcp.dpx64
│   ├── x64dbg_mcp.dpx32
│   └── README.md
├── INSTALL.md
└── ... (other source files)