### PR TITLE
fix: Correct plugin paths and add exclusions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,16 @@ jobs:
           --exclude='.DS_Store' \
           --exclude='*.swp' \
           --exclude='.claude' \
+          --exclude='release' \
+          --exclude='CODE_OF_CONDUCT.md' \
+          --exclude='RELEASING.md' \
+          --exclude='SECURITY.md' \
           . "$PACKAGE_NAME/"
 
         # Copy x64dbg plugins to dedicated directory
         mkdir -p "$PACKAGE_NAME/x64dbg-plugins"
-        cp release/x64dbg_mcp.dpx64 "$PACKAGE_NAME/x64dbg-plugins/"
-        cp release/x64dbg_mcp.dpx32 "$PACKAGE_NAME/x64dbg-plugins/"
+        cp release/x64dbg-plugins/x64dbg_mcp.dpx64 "$PACKAGE_NAME/x64dbg-plugins/"
+        cp release/x64dbg-plugins/x64dbg_mcp.dpx32 "$PACKAGE_NAME/x64dbg-plugins/"
 
         # Create installation instructions for plugins
         cat > "$PACKAGE_NAME/x64dbg-plugins/README.md" << 'EOF'


### PR DESCRIPTION
- Fixed plugin copy paths from release/ to release/x64dbg-plugins/
- Added exclusions for CODE_OF_CONDUCT.md, RELEASING.md, SECURITY.md
- Added exclusion for release/ directory to prevent copying build artifacts

This fixes the "cp: cannot stat 'release/x64dbg_mcp.dpx64'" error.