### PR TITLE
fix: Correct x64dbg plugin file extensions to standard .dp64/.dp32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,8 @@ jobs:
         Write-Host "Preparing release artifacts..."
         New-Item -ItemType Directory -Force -Path release/x64dbg-plugins
 
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dpx64 release/x64dbg-plugins/
-        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dpx32 release/x64dbg-plugins/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x64/Release/x64dbg_mcp.dp64 release/x64dbg-plugins/
+        Copy-Item src/engines/dynamic/x64dbg/plugin/build-x32/Release/x64dbg_mcp.dp32 release/x64dbg-plugins/
 
         Write-Host "Artifacts prepared in release/x64dbg-plugins/"
         Get-ChildItem release/x64dbg-plugins/
@@ -157,8 +157,8 @@ jobs:
 
         # Copy x64dbg plugins to dedicated directory
         mkdir -p "$PACKAGE_NAME/x64dbg-plugins"
-        cp release/x64dbg-plugins/x64dbg_mcp.dpx64 "$PACKAGE_NAME/x64dbg-plugins/"
-        cp release/x64dbg-plugins/x64dbg_mcp.dpx32 "$PACKAGE_NAME/x64dbg-plugins/"
+        cp release/x64dbg-plugins/x64dbg_mcp.dp64 "$PACKAGE_NAME/x64dbg-plugins/"
+        cp release/x64dbg-plugins/x64dbg_mcp.dp32 "$PACKAGE_NAME/x64dbg-plugins/"
 
         # Create installation instructions for plugins
         cat > "$PACKAGE_NAME/x64dbg-plugins/README.md" << 'EOF'
@@ -166,8 +166,8 @@ jobs:
 
         Copy the plugin files to your x64dbg installation:
 
-        - `x64dbg_mcp.dpx64` → `x64dbg/x64/plugins/`
-        - `x64dbg_mcp.dpx32` → `x64dbg/x32/plugins/`
+        - `x64dbg_mcp.dp64` → `x64dbg/x64/plugins/`
+        - `x64dbg_mcp.dp32` → `x64dbg/x32/plugins/`
 
         Then restart x64dbg.
         EOF
@@ -188,8 +188,8 @@ jobs:
         This release includes everything you need:
         - **MCP Server source code** - Full binary analysis server
         - **Pre-built x64dbg plugins** - Ready-to-use debugger plugins in `x64dbg-plugins/` directory
-          - `x64dbg_mcp.dpx64` - 64-bit debugger plugin
-          - `x64dbg_mcp.dpx32` - 32-bit debugger plugin
+          - `x64dbg_mcp.dp64` - 64-bit debugger plugin
+          - `x64dbg_mcp.dp32` - 32-bit debugger plugin
 
         ### Installation
 

--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -45,9 +45,9 @@ target_link_libraries(x64dbg_mcp PRIVATE
 
 # Platform-specific settings
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(PLUGIN_ARCH "x64")
+    set(PLUGIN_ARCH "64")
 else()
-    set(PLUGIN_ARCH "x32")
+    set(PLUGIN_ARCH "32")
 endif()
 
 # Output name: x64dbg_mcp.dp64 or x64dbg_mcp.dp32


### PR DESCRIPTION
## Summary
- Fixed plugin file extensions from non-standard `.dpx64`/`.dpx32` to standard `.dp64`/`.dp32`
- Ensures x64dbg properly recognizes and loads the plugins

## Changes
- Updated `CMakeLists.txt` to set `PLUGIN_ARCH` to "64"/"32" instead of "x64"/"x32"
- Updated `release.yml` workflow to reference correct file extensions in all locations
- Fixed documentation in release notes and plugin README

## Why This Matters
x64dbg uses the file extension to identify plugins:
- `.dp64` for 64-bit plugins (loaded by x64dbg.exe)
- `.dp32` for 32-bit plugins (loaded by x32dbg.exe)

The previous `.dpx64`/`.dpx32` extensions would prevent x64dbg from discovering the plugins.