### PR TITLE
fix: Use dynamic runtime to prevent DLL load crash

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -74,8 +74,11 @@ set_target_properties(x64dbg_mcp PROPERTIES
 # 3. We only call x64dbg APIs after the plugin is fully loaded
 # 4. This is the standard approach for x64dbg plugins
 if(MSVC)
-    # Use static runtime to avoid VC++ redistributable dependencies
-    set_property(TARGET x64dbg_mcp PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    # CRITICAL: Use DYNAMIC runtime to match x64dbg.exe
+    # Static runtime (/MT) causes "ModuleName: unknown" crashes due to heap corruption
+    # x64dbg uses dynamic runtime (/MD), so we must use it too
+    # This requires VC++ redistributables to be installed (standard for x64dbg users)
+    set_property(TARGET x64dbg_mcp PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL$<$<CONFIG:Debug>:Debug>")
 
     # Allow unresolved symbols - x64dbg provides them at runtime
     target_link_options(x64dbg_mcp PRIVATE
@@ -83,6 +86,7 @@ if(MSVC)
         "/IGNORE:4199"  # Suppress /FORCE:UNRESOLVED warning
     )
 
+    message(STATUS "Using DYNAMIC runtime library (/MD) to match x64dbg")
     message(STATUS "Using /FORCE:UNRESOLVED for x64dbg API functions")
 endif()
 


### PR DESCRIPTION
## Problem
Both x64dbg.exe and x32dbg.exe crash immediately when plugins are installed.

**Event Viewer Evidence:**
```
AppName: x64dbg.exe / x32dbg.exe
ExceptionCode: c0000005 (Access Violation)
ModuleName: unknown    ← Crashes BEFORE Windows identifies module
FaultingOffset: 00905a4d / 0000000300905a4d
```

"ModuleName: unknown" means the crash happens during **DLL_PROCESS_ATTACH** before the DLL is fully loaded.

## Root Cause: Runtime Library Mismatch

**Current (BROKEN):**
- Plugin: Static runtime (`/MT`) - isolated heap, isolated CRT
- x64dbg: Dynamic runtime (`/MD`) - shared heap, shared CRT

**What Happens:**
1. Plugin DLL starts loading
2. Global C++ objects initialize (std::thread, std::map, std::string in static members)
3. They allocate from plugin's isolated heap
4. x64dbg's loader tries to interact with them using x64dbg's heap
5. **Access violation 0xc0000005** - heap corruption
6. Crash before DLL finishes loading → "ModuleName: unknown"

## Solution

Switch plugin to **dynamic runtime** (`/MD`) to match x64dbg:
```cmake
# Before (BROKEN):
MSVC_RUNTIME_LIBRARY "MultiThreaded"  # Static /MT

# After (FIXED):
MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"  # Dynamic /MD
```

**Benefits:**
- ✅ Shared CRT with x64dbg - compatible heaps
- ✅ Standard approach for x64dbg plugins
- ✅ Fixes both x64dbg.exe and x32dbg.exe crashes
- ⚠️ Requires VC++ 2022 redistributables (already needed for x64dbg)

## Impact

Both `.dp64` and `.dp32` plugins will now:
- Use dynamic runtime matching x64dbg
- Share heap with host process
- Load without access violations

## Testing

After this merges, the plugins should load successfully without crashing x64dbg.