### PR TITLE
fix: Convert static C++ objects to heap pointers to prevent DLL load crash

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/http_server.h
+++ b/src/engines/dynamic/x64dbg/plugin/http_server.h
@@ -25,11 +25,14 @@ private:
     static std::string ExtractHeader(const std::string& request, const std::string& header);
     static void SaveTokenToFile(const std::string& token);  // Save token for client
 
-    static std::atomic<bool> s_running;
-    static std::thread s_thread;
-    static std::map<std::string, Handler> s_handlers;
+    // CRITICAL: Use pointers instead of static objects
+    // Static objects initialize during DLL_PROCESS_ATTACH which is too early and unsafe
+    // Pointers are just NULL until we allocate them in Initialize()
+    static std::atomic<bool>* s_running;
+    static std::thread* s_thread;
+    static std::map<std::string, Handler>* s_handlers;
     static int s_port;
-    static std::string s_auth_token;  // Authentication token
+    static std::string* s_auth_token;  // Authentication token
 };
 
 // JSON helper functions


### PR DESCRIPTION
## Problem
Still crashing after dynamic runtime fix with EXACT same signature:
```
Exception code: 0xc0000005 (Access Violation)
ModuleName: unknown
Fault offset: 0x00905a4d   ← EXACTLY THE SAME every time
```

The fault offset being identical across all crashes indicates a **specific bad instruction**, not random memory corruption.

## Root Cause: Global Static C++ Objects

The dynamic runtime fix didn't solve it because the real problem is global static members in `http_server.h`:

```cpp
// These constructors run during DLL_PROCESS_ATTACH - TOO EARLY!
static std::atomic<bool> s_running(false);      // Constructs during DLL load
static std::thread s_thread;                    // Default constructor runs
static std::map<std::string, Handler> s_handlers; // Allocates/initializes
static std::string s_auth_token;                // Allocates string buffer
```

**Timeline:**
1. Windows loads `x64dbg_mcp.dp64`/`.dp32`
2. **Loader lock is held** → Many operations unsafe
3. **Global static objects construct** → BEFORE DllMain, BEFORE pluginInit()
4. `std::thread` default constructor or `std::map` initialization does something unsafe
5. **Access violation 0xc0000005** at offset 0x00905a4d
6. Crash before DLL finishes loading → "ModuleName: unknown"

## Solution: Heap Pointers

Convert all static objects to **pointers** (just NULL during DLL load):

**Before (CRASHES):**
```cpp
static std::thread s_thread;  // Constructs during DLL_PROCESS_ATTACH ❌
```

**After (SAFE):**
```cpp
static std::thread* s_thread = nullptr;  // Just a NULL pointer ✓

// Later in Initialize() after DLL is loaded:
s_thread = new std::thread();  // Safe to construct now ✓
```

## Changes

### http_server.h
- Changed all static objects to pointers
- Added documentation explaining why

### http_server.cpp
- Initialize pointers to `nullptr` (no construction during DLL load)
- Allocate on heap in `Initialize()` after DLL is fully loaded
- Updated all code to dereference through pointers (`*s_running`, `s_thread->join()`, etc.)
- Added null checks before accessing
- Clean up allocations in `Shutdown()`

## Impact

This prevents **any** C++ object construction during DLL_PROCESS_ATTACH:
- ✅ No std::thread constructor during load
- ✅ No std::map allocation during load
- ✅ No std::string allocation during load
- ✅ Just simple NULL pointers during load
- ✅ Allocate later when safe

Should fix the consistent crash at fault offset 0x00905a4d.