### PR TITLE
fix: Resolve WinSock header conflicts with WIN32_LEAN_AND_MEAN

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/http_server.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/http_server.cpp
@@ -5,8 +5,7 @@
 #include <fstream>
 #include <random>
 #include <iomanip>
-#include <Windows.h>
-#include <wincrypt.h>
+#include <wincrypt.h>  // Windows.h already included via http_server.h
 
 #pragma comment(lib, "ws2_32.lib")
 #pragma comment(lib, "advapi32.lib")

--- a/src/engines/dynamic/x64dbg/plugin/http_server.h
+++ b/src/engines/dynamic/x64dbg/plugin/http_server.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#define WIN32_LEAN_AND_MEAN  // Exclude rarely-used stuff from Windows headers
+#include <winsock2.h>        // Must come before Windows.h to avoid conflicts
+#include <Windows.h>
 #include <string>
 #include <functional>
 #include <map>
 #include <atomic>
-#include <Windows.h>
 
 // Simple HTTP server for MCP bridge API
 class HttpServer {


### PR DESCRIPTION
## Problem

The v0.0.26-test build failed with 100+ WinSock redefinition errors:

```
error C2011: 'sockaddr': 'struct' type redefinition
error C2011: 'fd_set': 'struct' type redefinition
error C2375: 'WSAStartup': redefinition; different linkage
error C2375: 'socket': redefinition; different linkage
... (100+ similar errors)
```

## Root Cause

**Classic WinSock header conflict:**

1. `<Windows.h>` by default includes `winsock.h` (old WinSock 1.1)
2. We need `winsock2.h` for modern socket functions (`CreateThread` compatibility)
3. When both are included, they have conflicting type definitions
4. This causes massive compilation errors

### The Include Chain That Broke

```cpp
// http_server.h (after PR #47)
#include <Windows.h>  // Auto-includes winsock.h ❌

// http_server.cpp
#include "http_server.h"  // Gets winsock.h via Windows.h
#include <Windows.h>      // Gets winsock.h again
// ... socket code needs winsock2.h but has winsock.h ❌
```

## Solution

**Standard Windows/WinSock fix:**

### 1. Define `WIN32_LEAN_AND_MEAN`

```cpp
#define WIN32_LEAN_AND_MEAN  // Prevents Windows.h from including winsock.h
```

This macro tells `<Windows.h>` to exclude rarely-used APIs, including the old `winsock.h`.

### 2. Include `winsock2.h` BEFORE `Windows.h`

```cpp
#include <winsock2.h>  // Modern WinSock 2 - MUST come first
#include <Windows.h>   // Now won't conflict
```

Order matters! `winsock2.h` must be included before `Windows.h` to ensure we get WinSock 2 definitions.

### 3. Remove Redundant Includes

```cpp
// http_server.cpp - BEFORE
#include "http_server.h"
#include <Windows.h>  // ❌ Redundant - already in http_server.h

// http_server.cpp - AFTER
#include "http_server.h"  // Already has Windows.h ✅
```

## Changes Made

### http_server.h
```cpp
#pragma once

#define WIN32_LEAN_AND_MEAN  // NEW: Exclude winsock.h from Windows.h
#include <winsock2.h>        // NEW: Include WinSock 2 first
#include <Windows.h>         // Now safe
#include <string>
#include <functional>
#include <map>
#include <atomic>
```

### http_server.cpp
```cpp
#include "http_server.h"
#include "plugin.h"
#include <sstream>
#include <algorithm>
#include <fstream>
#include <random>
#include <iomanip>
#include <wincrypt.h>  // REMOVED: #include <Windows.h> (redundant)
```

## Why This Works

1. **`WIN32_LEAN_AND_MEAN`**: Prevents `Windows.h` from auto-including old `winsock.h`
2. **Include order**: `winsock2.h` before `Windows.h` ensures WinSock 2 definitions take precedence
3. **No conflicts**: Only one set of socket definitions (WinSock 2)

## Testing

After this fix:
- ✅ No WinSock redefinition errors
- ✅ Compiles cleanly with `CreateThread()` and socket functions
- ✅ Both http_server.cpp and commands.cpp compile successfully
- ✅ All 4 source files (plugin.cpp, http_server.cpp, commands.cpp, debugger_state.cpp) build

## Standard Practice

This is the **standard solution** for WinSock conflicts in Windows applications. Microsoft documentation explicitly recommends this approach.

## References

- [Microsoft: Creating a Basic Winsock Application](https://learn.microsoft.com/en-us/windows/win32/winsock/creating-a-basic-winsock-application)
- [WIN32_LEAN_AND_MEAN documentation](https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers)
- Related to PR #47 (CreateThread implementation)