### PR TITLE
docs: Update READMEs to reflect external process architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A Model Context Protocol (MCP) server that provides AI assistants with binary an
 2. **Java 21+** - Required by Ghidra
 3. **Python 3.12+**
 4. **x64dbg** (optional) - For dynamic analysis on Windows
+   - Requires x64dbg plugin (see [x64dbg plugin README](src/engines/dynamic/x64dbg/plugin/README.md))
+   - Uses external process architecture for stability
 
 ### Installation
 
@@ -178,6 +180,12 @@ delete_session("session-id")
 
 ### Dynamic Analysis (14 tools)
 
+**x64dbg Integration** - Uses external process architecture:
+- Plugin DLL (`x64dbg_mcp.dp64`) spawns HTTP server process
+- Named Pipe IPC for crash isolation
+- Server failures don't affect debugger
+- See [ARCHITECTURE.md](src/engines/dynamic/x64dbg/ARCHITECTURE.md) for details
+
 **Debugger Control:**
 - `x64dbg_connect`, `x64dbg_status`, `x64dbg_run`, `x64dbg_pause`
 - `x64dbg_step_into`, `x64dbg_step_over`
@@ -299,7 +307,11 @@ binary-mcp/
 │   │   │   ├── project_cache.py    # SHA256 caching
 │   │   │   └── scripts/
 │   │   │       └── core_analysis.py # Jython extraction
-│   │   └── dynamic/x64dbg/         # x64dbg integration
+│   │   └── dynamic/x64dbg/         # x64dbg integration (external process)
+│   │       ├── ARCHITECTURE.md     # Architecture documentation
+│   │       ├── pipe_protocol.h     # IPC protocol definitions
+│   │       ├── plugin/             # Plugin DLL (minimal stub)
+│   │       └── server/             # HTTP server (separate process)
 │   └── utils/
 │       ├── patterns.py             # API/crypto patterns
 │       └── session_manager.py      # Session storage

--- a/src/engines/dynamic/x64dbg/plugin/README.md
+++ b/src/engines/dynamic/x64dbg/plugin/README.md
@@ -4,15 +4,46 @@ Native x64dbg plugin that exposes debugger functionality via HTTP API for integr
 
 ## Architecture
 
+**External Process Design** - The plugin uses a two-process architecture for stability:
+
 ```
-MCP Server (Python) <--HTTP--> x64dbg Plugin (C++) <--SDK--> x64dbg Core
-     │                              │
-     │                              ├─ HTTP Server (port 8765)
-     │                              ├─ Command Handlers
-     │                              └─ Debugger State Manager
-     │
-     └─ bridge.py (HTTP client)
+┌──────────────────────────────────────────────────────────┐
+│ x64dbg.exe Process                                       │
+│                                                           │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │ x64dbg_mcp.dp64 (Plugin DLL - Minimal Stub)    │   │
+│  │                                                  │   │
+│  │  • Spawns HTTP server process                  │   │
+│  │  • Creates Named Pipe server                   │   │
+│  │  • Handles x64dbg API calls                    │   │
+│  │  • Named Pipe: \\.pipe\x64dbg_mcp              │   │
+│  │                                                  │   │
+│  │              ↕ Named Pipe IPC                   │   │
+│  └──────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────┘
+                          ↕
+┌──────────────────────────────────────────────────────────┐
+│ x64dbg_mcp_server.exe (Separate Process)                │
+│                                                           │
+│  • HTTP Server on port 8765                             │
+│  • Isolated from x64dbg crashes                         │
+│  • Communicates via Named Pipe                          │
+│  • Can restart without restarting x64dbg               │
+│                                                           │
+│              ↕ HTTP                                      │
+└──────────────────────────────────────────────────────────┘
+                          ↕
+         MCP Server (Python) via bridge.py
 ```
+
+**Why External Process?**
+- Prevents x64dbg crashes from HTTP server issues
+- Avoids Windows loader lock restrictions
+- No DEP/BEX64 violations
+- Easy to debug independently
+- Industry-standard plugin pattern
+
+See [ARCHITECTURE.md](../ARCHITECTURE.md) for detailed technical documentation.
 
 ## Building
 
@@ -35,33 +66,55 @@ cp -r x64dbg/src/sdk/* extern/x64dbg_sdk/
 
 ### Build Plugin
 
+The build system creates **two files**:
+1. **x64dbg_mcp.dp64** (or .dp32) - Plugin DLL
+2. **x64dbg_mcp_server.exe** - HTTP server executable
+
 ```bash
+# Navigate to plugin directory
+cd src/engines/dynamic/x64dbg/plugin
+
 # Create build directory
 mkdir build && cd build
 
 # Configure CMake
-cmake .. -DX64DBG_SDK_PATH="../extern/x64dbg_sdk"
+cmake .. -DX64DBG_SDK_PATH="../../../../../../extern/x64dbg_sdk"
 
-# Build
+# Build (creates BOTH plugin and server)
 cmake --build . --config Release
 
-# Output: x64dbg_mcp.dp64 (or .dp32 for 32-bit)
+# Output files:
+#   - x64dbg_mcp.dp64 (plugin DLL)
+#   - x64dbg_mcp_server.exe (HTTP server)
 ```
 
 ### Install Plugin
 
+**IMPORTANT**: Both files must be deployed together in the same directory!
+
 ```bash
-# Option 1: Manual install
-cp build/x64dbg_mcp.dp64 "C:/Program Files/x64dbg/x64/plugins/"
+# Option 1: Manual install (copy BOTH files)
+cp build/Release/x64dbg_mcp.dp64 "C:/Program Files/x64dbg/x64/plugins/"
+cp build/Release/x64dbg_mcp_server.exe "C:/Program Files/x64dbg/x64/plugins/"
 
 # Option 2: Auto-install (set environment variable)
 set X64DBG_DIR=C:/Program Files/x64dbg/x64
 cmake --build . --config Release
+# Both files are automatically copied to %X64DBG_DIR%/plugins/
+```
+
+**Deployment Structure:**
+```
+C:\Program Files\x64dbg\x64\plugins\
+├── x64dbg_mcp.dp64           # Plugin (loaded by x64dbg)
+└── x64dbg_mcp_server.exe     # Server (spawned by plugin)
 ```
 
 ## API Endpoints
 
 Base URL: `http://localhost:8765`
+
+**Note**: The HTTP server runs as a separate process (`x64dbg_mcp_server.exe`) spawned automatically by the plugin. Requests are forwarded to the plugin via Named Pipe IPC.
 
 ### Debugger Control
 
@@ -153,13 +206,29 @@ Response:
 ### Project Structure
 
 ```
-plugin/
-├── CMakeLists.txt         # Build configuration
-├── plugin.cpp/.h          # Plugin entry point
-├── http_server.cpp/.h     # HTTP server implementation
-├── commands.cpp/.h        # Command handlers
-└── debugger_state.cpp/.h  # State management
+src/engines/dynamic/x64dbg/
+├── ARCHITECTURE.md        # Detailed architecture documentation
+├── pipe_protocol.h        # Shared IPC protocol definitions
+├── plugin/
+│   ├── CMakeLists.txt     # Dual-target build (plugin + server)
+│   ├── plugin.h           # Plugin interface
+│   ├── plugin_new.cpp     # Minimal plugin stub (~200 lines)
+│   ├── plugin.cpp         # Old in-process version (deprecated)
+│   ├── http_server.cpp/.h # HTTP server (deprecated)
+│   ├── commands.cpp/.h    # Command handlers
+│   └── debugger_state.cpp/.h  # State management
+└── server/
+    └── main.cpp           # HTTP server executable (separate process)
 ```
+
+**Active Files** (External Process Architecture):
+- `plugin_new.cpp` - Spawns server, handles Named Pipe
+- `server/main.cpp` - HTTP server with Named Pipe client
+- `pipe_protocol.h` - Shared protocol definitions
+
+**Deprecated Files** (Old In-Process Architecture):
+- `plugin.cpp` - Old monolithic plugin
+- `http_server.cpp/.h` - In-process HTTP server (caused crashes)
 
 ### Adding New Endpoints
 
@@ -226,22 +295,51 @@ Script::Module::GetMainModulePath(buffer);
 - **Input validation**: Validate all addresses and sizes
 - **Memory safety**: Careful with buffer operations
 
-## Troubleshoints
+## Troubleshooting
 
 ### Plugin doesn't load
 - Check x64dbg log window for errors
 - Ensure SDK version matches x64dbg version
 - Verify DLL dependencies (use Dependency Walker)
+- Make sure `x64dbg_mcp_server.exe` is in same directory
+
+### Server process won't start
+**Symptoms**: Plugin loads but no HTTP server available
+
+**Check**:
+1. Verify `x64dbg_mcp_server.exe` exists in plugins directory
+2. Check x64dbg log for: `[MCP] HTTP server process started (PID: ...)`
+3. Try running server manually: `x64dbg_mcp_server.exe`
+4. Check Windows Event Viewer for application errors
+
+### Pipe connection failed
+**Symptoms**: Server starts but can't communicate with plugin
+
+**Check**:
+1. Only one x64dbg instance running (pipe name conflict)
+2. Antivirus not blocking Named Pipes
+3. x64dbg log shows: `[MCP] HTTP server connected to pipe`
+4. Check for firewall blocking local IPC
 
 ### HTTP server port conflict
 - Default port: 8765
-- Change in `plugin.cpp`: `HttpServer::Initialize(8765)`
+- Change by passing argument to server: `x64dbg_mcp_server.exe 9000`
 - Check if port is already in use: `netstat -ano | findstr 8765`
 
 ### Commands don't work
 - Ensure binary is loaded in x64dbg
 - Check debugger state with `/api/status`
 - Review x64dbg log for exceptions
+- Verify pipe communication: x64dbg log should show request messages
+
+### Server crashes
+**Good News**: x64dbg keeps running! The external process architecture isolates crashes.
+
+**To Debug**:
+1. Run server manually with console visible
+2. Attach debugger to `x64dbg_mcp_server.exe` process
+3. Check server console output for errors
+4. Server can be restarted without restarting x64dbg
 
 ## License
 


### PR DESCRIPTION
## Summary

Updates both README.md files to document the external process architecture implemented in PR #49.

## Changes

### Main README.md:
- Added note about external process architecture in prerequisites
- Updated Dynamic Analysis section with architecture overview
- Updated project structure to show plugin/ and server/ directories  
- Added links to ARCHITECTURE.md for detailed documentation

### Plugin README.md:
- Completely revised Architecture section with detailed diagrams
- Updated Building section to document dual-target build system
- Added deployment instructions (both files must be in same directory)
- Updated Project Structure to show active vs deprecated files
- Enhanced Troubleshooting with external process specific issues
- Added note that HTTP server runs as separate process

## Context

This PR contains the documentation updates that were made after PR #49 was merged. The original PR implemented the external process architecture but was merged before these README updates were completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)