### PR TITLE
fix: Update CMakeLists.txt to reference plugin.cpp

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -29,7 +29,7 @@ message(STATUS "Building for ${ARCH_BITS} architecture")
 # =============================================================================
 
 set(PLUGIN_SOURCES
-    plugin_new.cpp
+    plugin.cpp
 )
 
 set(PLUGIN_HEADERS


### PR DESCRIPTION
## Build Failure Fix

Fixes the CMake build error in release workflow:
```
CMake Error at CMakeLists.txt:41 (add_library):
  Cannot find source file:
    plugin_new.cpp
```

## Problem

In PR #51, we renamed `plugin_new.cpp` → `plugin.cpp`, but forgot to update `CMakeLists.txt` which still referenced the old filename.

## Solution

Updated line 32 of `CMakeLists.txt`:
```cmake
set(PLUGIN_SOURCES
    plugin.cpp  # was: plugin_new.cpp
)
```

## Testing

This will allow the v0.0.29-test release build to complete successfully.