### PR TITLE
fix: Add missing standard library includes for MSVC build

### DIFF
--- a/src/engines/dynamic/x64dbg/pipe_protocol.h
+++ b/src/engines/dynamic/x64dbg/pipe_protocol.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <cstdint>  // for uint32_t
+#include <cstddef>  // for size_t
 
 // Shared protocol definitions for Named Pipe communication
 // between x64dbg plugin (server) and HTTP server process (client)

--- a/src/engines/dynamic/x64dbg/server/main.cpp
+++ b/src/engines/dynamic/x64dbg/server/main.cpp
@@ -3,8 +3,10 @@
 #include <Windows.h>
 #include <iostream>
 #include <string>
+#include <vector>
 #include <atomic>
 #include <thread>
+#include <cstdarg>  // for va_list, va_start, va_end
 #include "../pipe_protocol.h"
 
 // Simple logging


### PR DESCRIPTION
## Build Fix for Windows

Fixes MSVC compilation errors in the GitHub Actions release workflow.

## Errors Fixed

### 1. pipe_protocol.h
**Error:**
```
error C2143: syntax error: missing '}' before 'constant'
error C2059: syntax error: 'constant'
```

**Cause:** Missing `#include <cstdint>` for `uint32_t` type used in enum definitions

**Fix:** Added:
```cpp
#include <cstdint>  // for uint32_t
#include <cstddef>  // for size_t
```

### 2. server/main.cpp
**Error:**
```
error C2039: 'vector': is not a member of 'std'
error C3861: 'Log': identifier not found
```

**Cause:** Missing includes for `std::vector` and `va_list` (variadic arguments)

**Fix:** Added:
```cpp
#include <vector>
#include <cstdarg>  // for va_list, va_start, va_end
```

## Testing

This will allow the MSVC compiler to:
1. Recognize `uint32_t` in enum class definitions
2. Find `std::vector` template
3. Find variadic argument macros for logging

## Related

Fixes build for v0.0.30-test release.