### PR TITLE
fix: Rename Status::ERROR to Status::FAILED (Windows macro conflict)

### DIFF
--- a/src/engines/dynamic/x64dbg/pipe_protocol.h
+++ b/src/engines/dynamic/x64dbg/pipe_protocol.h
@@ -26,7 +26,7 @@ namespace Protocol {
     // Response status codes
     enum class Status : uint32_t {
         SUCCESS = 0,
-        ERROR = 1,
+        FAILED = 1,             // Renamed from ERROR to avoid Windows macro conflict
         NOT_DEBUGGING = 2,
         INVALID_REQUEST = 3
     };


### PR DESCRIPTION
## Critical Build Fix

Fixes Windows macro conflict causing MSVC compilation to fail.

## Problem

`ERROR` is defined as a macro in Windows.h:
```c
#define ERROR 0
```

When MSVC compiles `pipe_protocol.h`, the preprocessor expands the enum:
```cpp
enum class Status : uint32_t {
    SUCCESS = 0,
    ERROR = 1,    // <-- Gets expanded to: 0 = 1,
    ...
};
```

This causes syntax errors:
```
error C2143: syntax error: missing '}' before 'constant'
error C2059: syntax error: 'constant'
```

## Solution

Renamed `ERROR` to `FAILED` in the Status enum:
```cpp
enum class Status : uint32_t {
    SUCCESS = 0,
    FAILED = 1,  // Renamed from ERROR
    NOT_DEBUGGING = 2,
    INVALID_REQUEST = 3
};
```

## Verification

- Searched codebase for `Status::ERROR` usage - none found
- This is a pure rename with no behavior changes
- Enum is only used in protocol documentation comments currently

## Testing

This should fix the persistent MSVC compilation errors in the GitHub Actions workflow.