### PR TITLE
fix: Change PLUGIN_VERSION_STR to PLUGIN_VERSION in LogInfo

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -185,7 +185,7 @@ static bool SpawnHTTPServer() {
 // Plugin initialization
 bool pluginInit(PLUG_INITSTRUCT* initStruct) {
     g_pluginHandle = initStruct->pluginHandle;
-    LogInfo("Initializing MCP Bridge Plugin v%s", PLUGIN_VERSION_STR);
+    LogInfo("Initializing MCP Bridge Plugin v%d", PLUGIN_VERSION);
     return true;
 }
 


### PR DESCRIPTION
## Build Error Fix

Fixes MSVC compilation error from v0.0.33-test build.

## Problem

In PR #56, we removed `PLUGIN_VERSION_STR` from `plugin.h` but forgot to update the code that references it:

```cpp
LogInfo("Initializing MCP Bridge Plugin v%s", PLUGIN_VERSION_STR);  // ← Undeclared!
```

This caused build error:
```
error C2065: 'PLUGIN_VERSION_STR': undeclared identifier
```

## Solution

Changed to use the numeric `PLUGIN_VERSION` instead:

```cpp
// Before:
LogInfo("Initializing MCP Bridge Plugin v%s", PLUGIN_VERSION_STR);

// After:
LogInfo("Initializing MCP Bridge Plugin v%d", PLUGIN_VERSION);
```

## Result

Log output will now show:
```
[MCP] Initializing MCP Bridge Plugin v1
```

Instead of a string version, which is cleaner anyway since we're just using a simple integer version.