### PR TITLE
fix: Link x64dbg bridge libraries to resolve BEX64 crash

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -47,6 +47,21 @@ target_include_directories(x64dbg_mcp PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
+# Find and link x64dbg bridge library (provides x64dbg API implementations)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(BRIDGE_LIB "${X64DBG_SDK_PATH}/pluginsdk/x64bridge.lib")
+else()
+    set(BRIDGE_LIB "${X64DBG_SDK_PATH}/pluginsdk/x32bridge.lib")
+endif()
+
+if(EXISTS "${BRIDGE_LIB}")
+    target_link_libraries(x64dbg_mcp PRIVATE "${BRIDGE_LIB}")
+    message(STATUS "Plugin: Linking bridge library: ${BRIDGE_LIB}")
+else()
+    message(WARNING "Bridge library not found: ${BRIDGE_LIB}")
+    message(WARNING "Plugin may fail to load without bridge library!")
+endif()
+
 # Output name: x64dbg_mcp.dp64 or x64dbg_mcp.dp32
 set_target_properties(x64dbg_mcp PROPERTIES
     OUTPUT_NAME "x64dbg_mcp"
@@ -57,15 +72,7 @@ set_target_properties(x64dbg_mcp PROPERTIES
 if(MSVC)
     # Use DYNAMIC runtime to match x64dbg
     set_property(TARGET x64dbg_mcp PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL$<$<CONFIG:Debug>:Debug>")
-
-    # Allow unresolved symbols - x64dbg provides them at runtime
-    target_link_options(x64dbg_mcp PRIVATE
-        "/FORCE:UNRESOLVED"
-        "/IGNORE:4199"
-    )
-
     message(STATUS "Plugin: Using DYNAMIC runtime library (/MD)")
-    message(STATUS "Plugin: Using /FORCE:UNRESOLVED for x64dbg API functions")
 endif()
 
 # =============================================================================


### PR DESCRIPTION
## Root Cause Analysis

After 15 test releases with the same BEX64 crash, I've identified the actual root cause:

### The Crash
- **Fault offset**: `0x0000000300905a4d` = **MZ header** (PE file signature)
- **Error**: BEX64 (Buffer Execution Exception) = Data Execution Prevention violation
- **What's happening**: CPU is trying to execute the PE file header as code instead of actual executable instructions

### Why It's Happening

**Our Previous Approach (BROKEN)**:
```cmake
target_link_options(x64dbg_mcp PRIVATE
    "/FORCE:UNRESOLVED"  # ← Allows unresolved symbols
    "/IGNORE:4199"
)
```

We were using `/FORCE:UNRESOLVED` expecting x64dbg to provide API symbols at runtime. This is **NOT** how x64dbg plugins work!

**Official PluginTemplate Approach (CORRECT)**:
```cmake
# Explicitly link bridge libraries
if(CMAKE_SIZEOF_VOID_P EQUAL 8)
    file(GLOB_RECURSE LIBS ${x64dbg_SOURCE_DIR}/pluginsdk/x64*.lib)
else()
    file(GLOB_RECURSE LIBS ${x64dbg_SOURCE_DIR}/pluginsdk/x32*.lib)
endif()
target_link_libraries(x64dbg INTERFACE ${LIBS})
```

The official template explicitly links `x64bridge.lib` (64-bit) or `x32bridge.lib` (32-bit), which provide the actual implementations of x64dbg SDK functions.

### Why This Caused the MZ Header Crash

Without proper linking, x64dbg API function calls in our code:
- `_plugin_logprintf()` (plugin.cpp:29, 38)
- `_plugin_menuaddentry()` (plugin.cpp:253-254)

...had **invalid jump addresses**. When the CPU tried to execute these functions, it jumped to bad addresses that pointed into the PE header section, causing it to execute the MZ header bytes as code → **BEX64 crash**.

## The Fix

This PR:
1. ✅ Removes `/FORCE:UNRESOLVED` and `/IGNORE:4199` linker flags
2. ✅ Adds proper bridge library detection (x64bridge.lib / x32bridge.lib)
3. ✅ Links bridge library to plugin target at build time
4. ✅ Adds helpful warnings if bridge library is missing

This matches the approach used by the official x64dbg PluginTemplate.

## Testing

After this fix:
- x64dbg API functions should be properly resolved at link time
- Plugin should load without crashing
- Both 32-bit and 64-bit versions should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)