### PR TITLE
fix: Link x64dbg.lib to resolve _plugin_* function symbols

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
+++ b/src/engines/dynamic/x64dbg/plugin/CMakeLists.txt
@@ -47,19 +47,30 @@ target_include_directories(x64dbg_mcp PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-# Find and link x64dbg bridge library (provides x64dbg API implementations)
+# Link x64dbg SDK libraries (provides x64dbg API implementations)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(X64DBG_LIB "${X64DBG_SDK_PATH}/pluginsdk/x64dbg.lib")
     set(BRIDGE_LIB "${X64DBG_SDK_PATH}/pluginsdk/x64bridge.lib")
 else()
+    set(X64DBG_LIB "${X64DBG_SDK_PATH}/pluginsdk/x32dbg.lib")
     set(BRIDGE_LIB "${X64DBG_SDK_PATH}/pluginsdk/x32bridge.lib")
 endif()
 
+# Link x64dbg.lib (provides _plugin_* functions like _plugin_logprintf)
+if(EXISTS "${X64DBG_LIB}")
+    target_link_libraries(x64dbg_mcp PRIVATE "${X64DBG_LIB}")
+    message(STATUS "Plugin: Linking x64dbg API library: ${X64DBG_LIB}")
+else()
+    message(WARNING "x64dbg library not found: ${X64DBG_LIB}")
+    message(WARNING "Plugin will fail to link without x64dbg library!")
+endif()
+
+# Link x64bridge.lib (provides Bridge_* functions)
 if(EXISTS "${BRIDGE_LIB}")
     target_link_libraries(x64dbg_mcp PRIVATE "${BRIDGE_LIB}")
     message(STATUS "Plugin: Linking bridge library: ${BRIDGE_LIB}")
 else()
     message(WARNING "Bridge library not found: ${BRIDGE_LIB}")
-    message(WARNING "Plugin may fail to load without bridge library!")
 endif()
 
 # Output name: x64dbg_mcp.dp64 or x64dbg_mcp.dp32


### PR DESCRIPTION
## Root Cause Identified

After extensive research, I discovered the actual issue with PR #58:

**PR #58 linked `x64bridge.lib`**, but the `_plugin_*` functions are NOT in that library!

### The Truth About x64dbg SDK Libraries

Research revealed that the x64dbg Plugin SDK contains TWO distinct libraries:

1. **`x64dbg.lib` / `x32dbg.lib`** - Contains `_plugin_*` API functions:
   - `_plugin_logprintf` (for logging)
   - `_plugin_menuaddentry` (for menu entries)
   - Other core plugin API functions

2. **`x64bridge.lib` / `x32bridge.lib`** - Contains `Bridge_*` IPC functions:
   - Inter-process communication between GUI and debugger core
   - `BridgeAlloc`, `BridgeFree`, etc.

### Why PR #58 Failed

PR #58 only linked `x64bridge.lib`, which caused linker errors:
```
plugin.obj : error LNK2019: unresolved external symbol __imp__plugin_logprintf
plugin.obj : error LNK2019: unresolved external symbol __imp__plugin_menuaddentry
```

The `_plugin_*` functions simply weren't available because we linked the wrong library!

### The Fix

This PR:
- ✅ Links **BOTH** `x64dbg.lib` (for `_plugin_*` functions)  
- ✅ **AND** `x64bridge.lib` (for `Bridge_*` functions)
- ✅ Matches the official PluginTemplate approach
- ✅ Should finally resolve the 16-release BEX64 crash

### Research Sources

- x64dbg Plugin SDK documentation confirms x64dbg.lib exports `_plugin_*` functions
- Official PluginTemplate cmake/x64dbg.cmake links both libraries using glob patterns:
  ```cmake
  file(GLOB_RECURSE LIBS
      ${x64dbg_SOURCE_DIR}/pluginsdk/*_x64.lib  # Includes BOTH libraries
      ${x64dbg_SOURCE_DIR}/pluginsdk/x64*.lib
  )
  ```

This is the correct fix that should allow the plugin to load successfully!