### PR TITLE
fix: Use HMODULE from DllMain to spawn HTTP server process

### DIFF
--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -13,6 +13,9 @@ int g_hMenuDisasm = 0;
 int g_hMenuDump = 0;
 int g_hMenuStack = 0;
 
+// DLL module handle (saved from DllMain)
+static HMODULE g_hModule = nullptr;
+
 // Server process handle
 static HANDLE g_serverProcess = nullptr;
 static HANDLE g_pipeServer = INVALID_HANDLE_VALUE;
@@ -136,8 +139,8 @@ static DWORD WINAPI PipeServerThread(LPVOID lpParam) {
 static bool SpawnHTTPServer() {
     // Get plugin directory
     char pluginPath[MAX_PATH];
-    if (!GetModuleFileNameA((HMODULE)g_pluginHandle, pluginPath, MAX_PATH)) {
-        LogError("Failed to get plugin path");
+    if (!GetModuleFileNameA(g_hModule, pluginPath, MAX_PATH)) {
+        LogError("Failed to get plugin path: %d", GetLastError());
         return false;
     }
 
@@ -284,6 +287,7 @@ extern "C" __declspec(dllexport) void plugsetup(PLUG_SETUPSTRUCT* setupStruct) {
 // DLL entry point
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_ATTACH) {
+        g_hModule = hinstDLL;  // Save module handle for later use
         DisableThreadLibraryCalls(hinstDLL);
     }
     return TRUE;


### PR DESCRIPTION
## 🎉 First, the GREAT NEWS!

**The plugin loaded successfully without crashing!** After 16 releases, the bridge library linking fix (PR #59) worked! x64dbg launched with the plugin loaded:

```
[pluginload] x64dbg_mcp
[MCP] Initializing MCP Bridge Plugin v1
[PLUGIN] x64dbg_mcp v1 Loaded!
[MCP] Setting up plugin
[MCP] Named Pipe server thread starting...
[MCP] Waiting for HTTP server to connect...
```

**No more BEX64 crash!** 🎊

## The New Issue

However, the HTTP server process failed to spawn:

```
[MCP ERROR] Failed to get plugin path
[MCP ERROR] Failed to spawn HTTP server
```

## Root Cause

The problem was in `SpawnHTTPServer()` at plugin.cpp:142:

```cpp
if (!GetModuleFileNameA((HMODULE)g_pluginHandle, pluginPath, MAX_PATH)) {
```

We were casting `g_pluginHandle` (an `int`) to `HMODULE`, which is invalid. The compiler even warned us:

```
warning C4312: 'type cast': conversion from 'int' to 'HMODULE' of greater size
```

This caused `GetModuleFileNameA()` to fail, so the plugin couldn't find its own DLL path or locate `x64dbg_mcp_server.exe`.

## The Fix

This PR:

1. ✅ Adds `g_hModule` static variable to store the DLL's `HMODULE`
2. ✅ Updates `DllMain()` to save `HINSTANCE` during `DLL_PROCESS_ATTACH`
3. ✅ Updates `SpawnHTTPServer()` to use `g_hModule` instead of casting `g_pluginHandle`
4. ✅ Adds error code logging to `GetModuleFileNameA()` for better debugging

## Expected Result

After this fix, the plugin should:
- ✅ Load without crashing (already working!)
- ✅ Get its own DLL path correctly
- ✅ Find `x64dbg_mcp_server.exe` in the plugins directory  
- ✅ Successfully spawn the HTTP server process
- ✅ Establish Named Pipe communication

This should complete the external process architecture implementation!

🤖 Generated with [Claude Code](https://claude.com/claude-code)