### PR TITLE
fix: Update HTTP server routes to include /api prefix

### DIFF
--- a/src/engines/dynamic/x64dbg/server/main.cpp
+++ b/src/engines/dynamic/x64dbg/server/main.cpp
@@ -266,8 +266,8 @@ std::string HandleHTTPRequest(const std::string& request) {
                                 "{\"status\":\"ok\",\"message\":\"x64dbg MCP server running\"}");
     }
 
-    // Handle GET /status
-    if (method == "GET" && path == "/status") {
+    // Handle GET /api/status
+    if (method == "GET" && path == "/api/status") {
         // Send GET_STATE request to plugin
         std::string pipeResponse;
         if (g_pipeClient.SendRequest("{\"type\":1}", pipeResponse)) {
@@ -278,8 +278,8 @@ std::string HandleHTTPRequest(const std::string& request) {
         }
     }
 
-    // Handle POST requests (extract JSON body and forward to plugin)
-    if (method == "POST") {
+    // Handle POST requests to /api/* endpoints (extract JSON body and forward to plugin)
+    if (method == "POST" && path.rfind("/api/", 0) == 0) {
         // Find body (after \r\n\r\n)
         size_t bodyStart = request.find("\r\n\r\n");
         if (bodyStart == std::string::npos) {


### PR DESCRIPTION
## Summary
- Changed GET /status to GET /api/status
- Added /api/* validation for POST requests
- Aligns server routes with Python bridge expectations

## Problem
Python bridge requests URLs like `/api/status`, `/api/registers`, etc., but HTTP server only handled `/status` without the `/api` prefix, causing 404 errors.

## Solution
Updated HTTP server routing to handle `/api/*` endpoints that match what the Python bridge expects.

## Test Plan
1. Rebuild x64dbg_mcp_server.exe with updated code
2. Restart x64dbg with plugin loaded
3. Test connection from Claude Code using `x64dbg_status()` tool
4. Verify no more 404 errors in logs

## Fixes
Resolves 404 Client Error: Not Found for url: http://127.0.0.1:8765/api/status