### PR TITLE
feat: Add binary compatibility checker for pre-analysis validation

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -22,10 +22,7 @@ from src.engines.static.ghidra.runner import GhidraRunner
 from src.tools.dynamic_tools import register_dynamic_tools
 from src.utils.compatibility import (
     BinaryCompatibilityChecker,
-    BinaryFormat,
     CompatibilityLevel,
-    check_binary_compatibility,
-    format_compatibility_report,
 )
 from src.utils.patterns import APIPatterns, CryptoPatterns
 from src.utils.security import (

--- a/src/utils/compatibility.py
+++ b/src/utils/compatibility.py
@@ -209,7 +209,7 @@ class BinaryCompatibilityChecker:
             # Distinguish by checking if it looks like Java class file
             if len(header) >= 8:
                 # Java class has version numbers after magic
-                minor_version = struct.unpack('>H', header[4:6])[0]
+                # minor_version at offset 4-6, major_version at offset 6-8
                 major_version = struct.unpack('>H', header[6:8])[0]
                 # Java versions are typically 45-65 for major
                 if 45 <= major_version <= 70:
@@ -299,8 +299,7 @@ class BinaryCompatibilityChecker:
                 clr_data = pe.get_data(clr_rva, min(clr_dir.Size, 72))
 
                 if len(clr_data) >= 16:
-                    # Parse COR20 header
-                    cb = struct.unpack('<I', clr_data[0:4])[0]
+                    # Parse COR20 header (cb at offset 0-4, runtime version at 4-8)
                     major_runtime = struct.unpack('<H', clr_data[4:6])[0]
                     minor_runtime = struct.unpack('<H', clr_data[6:8])[0]
                     flags = struct.unpack('<I', clr_data[16:20])[0] if len(clr_data) >= 20 else 0


### PR DESCRIPTION
Add a pre-analysis binary compatibility checker that detects format, architecture, and potential issues BEFORE invoking Ghidra. This provides early warnings while still proceeding with analysis.

Key changes:
- New src/utils/compatibility.py module with BinaryCompatibilityChecker
- Detects .NET assemblies, packed binaries, and unsupported formats
- New check_binary() MCP tool for standalone compatibility checks
- analyze_binary() shows compatibility warnings but still runs analysis
- Warnings appear at top of output so LLM understands limitations
- skip_compatibility_check parameter available to suppress warnings

Supported detections:
- Binary formats: PE, ELF, Mach-O, .NET/CLR, Java Class
- Architectures: x86, x64, ARM, ARM64
- .NET obfuscators: ConfuserEx, Dotfuscator, VMProtect, Themida
- Packers: UPX, ASPack, PECompact, and 15+ others
