### PR TITLE
fix: resolve Ghidra encoding failures and x64dbg parameter loss on Windows

### DIFF
--- a/src/engines/dynamic/x64dbg/bridge.py
+++ b/src/engines/dynamic/x64dbg/bridge.py
@@ -1994,6 +1994,9 @@ class X64DbgBridge(Debugger):
 
     # Commands that must never reach DbgCmdExec — they load external code,
     # write arbitrary files, or compromise the debugging session.
+    # Trace configuration commands are also blocked here because their
+    # arguments (arbitrary commands, file paths) bypass validation — use
+    # the dedicated set_trace_command / set_trace_log_file methods instead.
     _BLOCKED_COMMANDS = frozenset({
         "scriptdll", "scriptload", "scriptrun",
         "loadlib", "freelib",
@@ -2002,6 +2005,7 @@ class X64DbgBridge(Debugger):
         "detach", "attach", "init",
         "exec", "execute",
         "createthread",
+        "tracesetcommand", "tracesetlog", "tracesetlogfile",
     })
 
     def _validate_command(self, command: str) -> None:
@@ -5719,15 +5723,25 @@ class X64DbgBridge(Debugger):
         """
         Configure a command to execute at each trace step.
 
+        The inner command is validated against the blocked commands list
+        to prevent staging dangerous commands (ScriptDll, loadlib, etc.)
+        for execution by the trace engine.
+
         Args:
             command: x64dbg command to run per step
             condition: Optional condition — only run when true
 
         Returns:
             Command result dictionary
+
+        Raises:
+            ValueError: If the inner command is blocked for security reasons
         """
         if not command or not command.strip():
             raise ValueError("Trace command cannot be empty")
+        # Validate the INNER command against the blocklist — the trace engine
+        # will execute it directly, bypassing the normal command validation path.
+        self._validate_command(command.strip())
         cmd = f"TraceSetCommand {command.strip()}"
         if condition and condition.strip():
             cmd += f", {condition.strip()}"

--- a/src/engines/dynamic/x64dbg/bridge.py
+++ b/src/engines/dynamic/x64dbg/bridge.py
@@ -1992,19 +1992,50 @@ class X64DbgBridge(Debugger):
             "message": result.get("message", "Instruction undone"),
         }
 
+    # Commands that must never reach DbgCmdExec — they load external code,
+    # write arbitrary files, or compromise the debugging session.
+    _BLOCKED_COMMANDS = frozenset({
+        "scriptdll", "scriptload", "scriptrun",
+        "loadlib", "freelib",
+        "savedata", "savefile",
+        "quit", "stop", "exit",
+        "detach", "attach", "init",
+        "exec", "execute",
+        "createthread",
+    })
+
+    def _validate_command(self, command: str) -> None:
+        """
+        Validate a command against the blocked commands list.
+
+        Raises:
+            ValueError: If the command is blocked for security reasons
+        """
+        first_token = command.strip().split()[0].split("(")[0].lower()
+        if first_token in self._BLOCKED_COMMANDS:
+            raise ValueError(
+                f"Command '{first_token}' is blocked by security policy. "
+                f"This command could load external code or compromise the session."
+            )
+
     def execute_command(self, command: str) -> dict[str, Any]:
         """
-        Execute an arbitrary x64dbg command via the command API.
+        Execute an x64dbg command via the command API.
 
-        This is a low-level method that sends any command string to x64dbg.
-        Security validation should be performed by the caller (MCP tool layer).
+        Commands are validated against a blocklist of dangerous operations
+        (ScriptDll, loadlib, savedata, etc.) before being sent. The plugin
+        also enforces its own server-side blocklist as defense-in-depth.
 
         Args:
             command: The x64dbg command string to execute
 
         Returns:
             Dictionary with command result from the API
+
+        Raises:
+            ValueError: If the command is blocked for security reasons
         """
+        self._validate_command(command)
         result = self._request_with_retry("/api/command", {"command": command})
         return result
 

--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -3631,6 +3631,7 @@ static const char* BLOCKED_COMMAND_PREFIXES[] = {
     "detach", "attach", "init",
     "exec", "execute",
     "createthread",
+    "tracesetcommand", "tracesetlog", "tracesetlogfile",
     nullptr  // sentinel
 };
 

--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -3619,7 +3619,39 @@ void OnSystemBreakpoint(CBTYPE cbType, PLUG_CB_SYSTEMBREAKPOINT* info) {
     );
 }
 
-// Handler: EXECUTE_COMMAND - Execute an arbitrary x64dbg command
+// Defense-in-depth: server-side allowlist for EXECUTE_COMMAND.
+// Blocks commands that could load external code, write arbitrary files,
+// or compromise the debugger/analyst host. The Python layer has its own
+// allowlist; this is a safety net in case it is bypassed.
+static const char* BLOCKED_COMMAND_PREFIXES[] = {
+    "scriptdll", "scriptload", "scriptrun",
+    "loadlib", "freelib",
+    "savedata", "savefile",
+    "quit", "stop", "exit",
+    "detach", "attach", "init",
+    "exec", "execute",
+    "createthread",
+    nullptr  // sentinel
+};
+
+static bool IsCommandBlocked(const std::string& command) {
+    // Extract first word, lowercased
+    std::string firstWord;
+    for (size_t i = 0; i < command.size(); i++) {
+        char c = command[i];
+        if (c == ' ' || c == '\t' || c == '(' || c == ',') break;
+        firstWord += (char)tolower((unsigned char)c);
+    }
+
+    for (int i = 0; BLOCKED_COMMAND_PREFIXES[i] != nullptr; i++) {
+        if (firstWord == BLOCKED_COMMAND_PREFIXES[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Handler: EXECUTE_COMMAND - Execute a validated x64dbg command
 std::string HandleExecuteCommand(const std::string& request) {
     std::string command = ExtractStringField(request, "command");
     if (command.empty()) {
@@ -3628,6 +3660,12 @@ std::string HandleExecuteCommand(const std::string& request) {
 
     if (!DbgIsDebugging()) {
         return BuildJsonResponse(false, "\"error\":\"Not debugging - load a binary first\"");
+    }
+
+    // Defense-in-depth: reject dangerous commands at the plugin level
+    if (IsCommandBlocked(command)) {
+        LogInfo("Blocked dangerous command: %s", command.c_str());
+        return BuildJsonResponse(false, "\"error\":\"Command blocked by security policy\"");
     }
 
     LogInfo("Executing command: %s", command.c_str());

--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -37,6 +37,7 @@ enum RequestType {
     GET_STACK = 13,
     GET_MODULES = 14,
     GET_THREADS = 15,
+    EXECUTE_COMMAND = 16,
 
     // Breakpoints
     SET_BREAKPOINT = 20,
@@ -3618,6 +3619,31 @@ void OnSystemBreakpoint(CBTYPE cbType, PLUG_CB_SYSTEMBREAKPOINT* info) {
     );
 }
 
+// Handler: EXECUTE_COMMAND - Execute an arbitrary x64dbg command
+std::string HandleExecuteCommand(const std::string& request) {
+    std::string command = ExtractStringField(request, "command");
+    if (command.empty()) {
+        return BuildJsonResponse(false, "\"error\":\"Missing command parameter\"");
+    }
+
+    if (!DbgIsDebugging()) {
+        return BuildJsonResponse(false, "\"error\":\"Not debugging - load a binary first\"");
+    }
+
+    LogInfo("Executing command: %s", command.c_str());
+
+    if (DbgCmdExec(command.c_str())) {
+        std::stringstream data;
+        data << "\"command\":\"" << JsonEscape(command) << "\","
+             << "\"executed\":true";
+        return BuildJsonResponse(true, data.str());
+    } else {
+        std::stringstream data;
+        data << "\"error\":\"Command failed: " << JsonEscape(command) << "\"";
+        return BuildJsonResponse(false, data.str());
+    }
+}
+
 // Handler: LOAD_BINARY - Load binary into debugger
 std::string HandleLoadBinary(const std::string& request) {
     std::string path = ExtractStringField(request, "path");
@@ -3757,6 +3783,9 @@ static DWORD WINAPI PipeServerThread(LPVOID lpParam) {
                         break;
                     case LOAD_BINARY:
                         response = HandleLoadBinary(request);
+                        break;
+                    case EXECUTE_COMMAND:
+                        response = HandleExecuteCommand(request);
                         break;
                     case GET_REGISTERS:
                         response = HandleGetRegisters(request);

--- a/src/engines/dynamic/x64dbg/server/main.cpp
+++ b/src/engines/dynamic/x64dbg/server/main.cpp
@@ -354,6 +354,8 @@ std::string HandleHTTPRequest(const std::string& request) {
         requestType = 20;  // SET_BREAKPOINT
 
     // Core Functionality (Not Yet Implemented)
+    } else if (path == "/api/command") {
+        requestType = 16;  // EXECUTE_COMMAND
     } else if (path == "/api/load") {
         requestType = 2;  // LOAD_BINARY
     } else if (path == "/api/run") {
@@ -643,19 +645,54 @@ bool StartHTTPServer(int port) {
         int sendTimeout = 5000;
         setsockopt(clientSocket, SOL_SOCKET, SO_SNDTIMEO, (const char*)&sendTimeout, sizeof(sendTimeout));
 
-        // Read HTTP request
-        char buffer[8192];
-        int bytesRead = recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
+        // Read HTTP request - loop until we have the full body
+        std::string request;
+        {
+            char buffer[8192];
+            int bytesRead = recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
 
-        if (bytesRead > 0) {
-            buffer[bytesRead] = '\0';
-            std::string request(buffer, bytesRead);
+            if (bytesRead > 0) {
+                request.assign(buffer, bytesRead);
 
+                // For POST requests, ensure we receive the full body
+                // by checking Content-Length against actual body received
+                size_t headerEnd = request.find("\r\n\r\n");
+                if (headerEnd != std::string::npos) {
+                    // Extract Content-Length from headers
+                    int contentLength = 0;
+                    std::string clHeader = "Content-Length:";
+                    size_t clPos = request.find(clHeader);
+                    if (clPos == std::string::npos) {
+                        clHeader = "content-length:";
+                        clPos = request.find(clHeader);
+                    }
+                    if (clPos != std::string::npos) {
+                        size_t valStart = clPos + clHeader.length();
+                        while (valStart < request.length() && request[valStart] == ' ') valStart++;
+                        contentLength = atoi(request.c_str() + valStart);
+                    }
+
+                    // Calculate how much body we've received so far
+                    size_t bodyStart = headerEnd + 4;
+                    size_t bodyReceived = request.length() - bodyStart;
+
+                    // Keep reading until we have the full body
+                    while (contentLength > 0 && (int)bodyReceived < contentLength) {
+                        bytesRead = recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
+                        if (bytesRead <= 0) break;
+                        request.append(buffer, bytesRead);
+                        bodyReceived += bytesRead;
+                    }
+                }
+            } else if (bytesRead == SOCKET_ERROR) {
+                Log("Recv failed: %d", WSAGetLastError());
+            }
+        }
+
+        if (!request.empty()) {
             // Handle request and send response
             std::string response = HandleHTTPRequest(request);
             send(clientSocket, response.c_str(), (int)response.size(), 0);
-        } else if (bytesRead == SOCKET_ERROR) {
-            Log("Recv failed: %d", WSAGetLastError());
         }
 
         closesocket(clientSocket);

--- a/src/engines/static/ghidra/analysis_session.py
+++ b/src/engines/static/ghidra/analysis_session.py
@@ -198,7 +198,7 @@ class AnalysisSession:
             }
 
             # Save metadata
-            with open(metadata_path, "w") as f:
+            with open(metadata_path, "w", encoding="utf-8") as f:
                 json.dump(metadata, f, indent=2)
 
             logger.info(f"Saved session: {session_data.get('name')} (ID: {session_id[:8]}..., {tool_count} tools, {total_output_size / 1024:.1f} KB)")
@@ -259,7 +259,7 @@ class AnalysisSession:
             if not metadata_path.exists():
                 return None
 
-            with open(metadata_path) as f:
+            with open(metadata_path, encoding="utf-8") as f:
                 return json.load(f)
 
         except Exception as e:
@@ -341,7 +341,7 @@ class AnalysisSession:
 
         for meta_file in self.store_dir.glob("*.meta.json"):
             try:
-                with open(meta_file) as f:
+                with open(meta_file, encoding="utf-8") as f:
                     metadata = json.load(f)
 
                 # Apply filters

--- a/src/engines/static/ghidra/project_cache.py
+++ b/src/engines/static/ghidra/project_cache.py
@@ -90,7 +90,7 @@ class ProjectCache:
                 logger.debug(f"No cache found for {binary_path}")
                 return None
 
-            with open(cache_path) as f:
+            with open(cache_path, encoding="utf-8") as f:
                 data = json.load(f)
 
             logger.info(f"Cache hit for {binary_path} (hash: {binary_hash[:8]}...)")
@@ -117,7 +117,7 @@ class ProjectCache:
             metadata_path = self._get_metadata_path(binary_hash)
 
             # Save analysis data
-            with open(cache_path, "w") as f:
+            with open(cache_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
 
             # Save metadata
@@ -129,7 +129,7 @@ class ProjectCache:
                 "cache_version": "1.0",
             }
 
-            with open(metadata_path, "w") as f:
+            with open(metadata_path, "w", encoding="utf-8") as f:
                 json.dump(metadata, f, indent=2)
 
             logger.info(f"Saved cache for {binary_path} (hash: {binary_hash[:8]}...)")
@@ -183,7 +183,7 @@ class ProjectCache:
             if not metadata_path.exists():
                 return None
 
-            with open(metadata_path) as f:
+            with open(metadata_path, encoding="utf-8") as f:
                 return json.load(f)
 
         except Exception as e:
@@ -201,7 +201,7 @@ class ProjectCache:
 
         for meta_file in self.cache_dir.glob("*.meta.json"):
             try:
-                with open(meta_file) as f:
+                with open(meta_file, encoding="utf-8") as f:
                     metadata = json.load(f)
                 cached_binaries.append(metadata)
             except Exception as e:

--- a/src/engines/static/ghidra/runner.py
+++ b/src/engines/static/ghidra/runner.py
@@ -320,6 +320,8 @@ class GhidraRunner:
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 shell=False,  # Changed: shell=False to fix Windows path handling
                 check=True,
@@ -391,6 +393,8 @@ class GhidraRunner:
                 ["java", "-version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             diag["java_installed"] = True
@@ -403,7 +407,7 @@ class GhidraRunner:
         version_file = self.ghidra_path / "application.properties"
         if version_file.exists():
             try:
-                with open(version_file) as f:
+                with open(version_file, encoding="utf-8") as f:
                     for line in f:
                         if line.startswith("application.version"):
                             diag["ghidra_version"] = line.split("=")[1].strip()

--- a/src/server.py
+++ b/src/server.py
@@ -402,7 +402,7 @@ def get_analysis_context(
             raise UserFacingError(user_message, internal_details=internal_details)
 
         # Load analysis results
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             context = json.load(f)
 
         # Validate the analysis context has meaningful data

--- a/src/tools/control_flow_tools.py
+++ b/src/tools/control_flow_tools.py
@@ -67,7 +67,7 @@ def _get_or_run_analysis(binary_path: str, cache, runner) -> dict:
             "Ghidra did not produce output. The binary format may be unsupported."
         )
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         context = json.load(f)
 
     cache.save_cached(str(binary_path), context)

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -3743,9 +3743,50 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_undo_instruction failed: {e}")
             return f"Error: {e}"
 
-    # Security: blocked commands that could disrupt the debugging session
-    blocked_commands = frozenset({
-        "quit", "stop", "exit", "detach", "attach", "init",
+    # Security: allowlist of safe x64dbg command prefixes.
+    # Only commands starting with these words are permitted through execute_command.
+    # This prevents arbitrary code execution via ScriptDll, loadlib, savedata, etc.
+    # Internal bridge methods (watches, types, trace, etc.) bypass this check since
+    # they construct commands from validated parameters with known-safe prefixes.
+    _ALLOWED_COMMAND_PREFIXES = frozenset({
+        # Analysis & navigation
+        "dis", "dis.prev", "dis.next", "dis.iscall", "dis.isbranch",
+        "findall", "find", "findmem", "findallmem",
+        "log", "msg",
+        "graph", "graphit",
+        # Breakpoint listing/info (setting is handled by dedicated tools)
+        "bplist", "bphitcount",
+        # Analysis commands
+        "cfanalyze", "analxrefs", "analrecur", "analadv", "analyse",
+        "exhandlers", "exinfo",
+        "rtu",
+        "instrundo",
+        # Search & reference
+        "ref", "refstr", "refsearch", "refinfo",
+        "modcallfind",
+        # Expression evaluation (read-only)
+        "eval",
+        # Labels and comments (annotation, not code exec)
+        "lbl", "lblset", "lbldel", "lbllist",
+        "cmt", "cmtset", "cmtdel", "cmtlist",
+        # Bookmarks
+        "bm", "bmset", "bmdel", "bmlist",
+        # Variable inspection (read-only)
+        "varlist", "var",
+        # Type system
+        "addstruct", "addunion", "addmember", "addtype",
+        "visittype", "sizeoftype", "removetype",
+        "enumtypes", "cleartypes", "loadtypes", "parsetypes",
+        # Watch expressions
+        "addwatch", "delwatch", "setwatchdog",
+        "setwatchexpression", "setwatchname",
+        # DLL breakpoints
+        "bpdll", "bcdll", "bpedll", "bpddll",
+        # Trace configuration (setting trace params, not loading code)
+        "tracesetcommand", "tracesetlog", "tracesetlogfile",
+        "tracesetcondition",
+        # Dump/view (read-only inspection)
+        "dump", "sdump",
     })
 
     @app.tool()
@@ -3754,9 +3795,11 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
         """
         Execute a generic x64dbg command.
 
-        Sends an arbitrary command string to x64dbg for execution.
-        Dangerous commands (quit, stop, exit, detach, attach, init)
-        are blocked for safety.
+        Sends a command string to x64dbg for execution. Only commands from
+        a curated allowlist of safe analysis/navigation commands are permitted.
+        Commands that could load external code (ScriptDll, loadlib), write
+        arbitrary files (savedata), or disrupt the session (quit, detach)
+        are rejected.
 
         Args:
             command: x64dbg command string (e.g. "dis.prev(rip, 5)", "findall 0, E8")
@@ -3766,8 +3809,8 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
 
         Use Cases:
             - Run analysis commands not covered by other tools
-            - Execute script commands
-            - Access advanced x64dbg features
+            - Navigate disassembly
+            - Search for patterns and references
 
         Examples:
             x64dbg_execute_command("dis.prev(rip, 5)")
@@ -3778,12 +3821,17 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             if not command or not command.strip():
                 return "Error: Command cannot be empty"
 
-            # Security: block dangerous commands by checking the first word
-            first_word = command.strip().split()[0].lower()
-            if first_word in blocked_commands:
+            # Security: only allow commands from the curated safe allowlist.
+            # Extract the command name (first word, before any space/paren/comma).
+            cmd_stripped = command.strip()
+            # Handle commands like "dis.prev(rip, 5)" -> "dis.prev"
+            first_token = cmd_stripped.split()[0].split("(")[0].split(",")[0].lower()
+            if first_token not in _ALLOWED_COMMAND_PREFIXES:
                 return (
-                    f"Error: Command '{first_word}' is blocked for safety. "
-                    f"Blocked commands: {', '.join(sorted(blocked_commands))}"
+                    f"Error: Command '{first_token}' is not in the allowed command list. "
+                    f"Only safe analysis and navigation commands are permitted. "
+                    f"Use dedicated tools (x64dbg_set_breakpoint, x64dbg_read_memory, etc.) "
+                    f"for other operations."
                 )
 
             bridge = get_x64dbg_bridge()

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -1617,8 +1617,8 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
                     module = api_modules.get(api_name, "kernel32")
 
                     # Use x64dbg's expression evaluation to get API address
-                    # Format: module.apiname
-                    api_expr = f"{module}.{api_name}"
+                    # Format: module!apiname (x64dbg symbol syntax)
+                    api_expr = f"{module}!{api_name}"
 
                     # Set conditional breakpoint that logs and continues
                     # This uses x64dbg's logging breakpoint feature

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -3748,7 +3748,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
     # This prevents arbitrary code execution via ScriptDll, loadlib, savedata, etc.
     # Internal bridge methods (watches, types, trace, etc.) bypass this check since
     # they construct commands from validated parameters with known-safe prefixes.
-    _ALLOWED_COMMAND_PREFIXES = frozenset({
+    allowed_command_prefixes = frozenset({
         # Analysis & navigation
         "dis", "dis.prev", "dis.next", "dis.iscall", "dis.isbranch",
         "findall", "find", "findmem", "findallmem",
@@ -3829,7 +3829,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             cmd_stripped = command.strip()
             # Handle commands like "dis.prev(rip, 5)" -> "dis.prev"
             first_token = cmd_stripped.split()[0].split("(")[0].split(",")[0].lower()
-            if first_token not in _ALLOWED_COMMAND_PREFIXES:
+            if first_token not in allowed_command_prefixes:
                 return (
                     f"Error: Command '{first_token}' is not in the allowed command list. "
                     f"Only safe analysis and navigation commands are permitted. "

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -3782,8 +3782,11 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
         "setwatchexpression", "setwatchname",
         # DLL breakpoints
         "bpdll", "bcdll", "bpedll", "bpddll",
-        # Trace configuration (setting trace params, not loading code)
-        "tracesetcommand", "tracesetlog", "tracesetlogfile",
+        # Trace configuration — tracesetcommand, tracesetlog, tracesetlogfile
+        # are intentionally EXCLUDED from this allowlist because their arguments
+        # (arbitrary commands, file paths) bypass security validation. Use the
+        # dedicated tools x64dbg_set_trace_command and x64dbg_set_trace_log_file
+        # which apply proper validation.
         "tracesetcondition",
         # Dump/view (read-only inspection)
         "dump", "sdump",

--- a/src/tools/malware_tools.py
+++ b/src/tools/malware_tools.py
@@ -709,7 +709,7 @@ def register_malware_tools(app, session_manager, cache, runner, api_patterns):
                 f"stderr: {result.get('stderr', 'N/A')[:500]}"
             )
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             context = json.load(f)
 
         cache.save_cached(bp, context)


### PR DESCRIPTION

- Add explicit UTF-8 encoding to all open() calls reading Ghidra JSON output, preventing Windows charmap codec errors on binary-derived content
- Add encoding='utf-8' with errors='replace' to subprocess.run() calls for Ghidra analysis and Java version checks
- Fix HTTP server body reception: add Content-Length parsing and recv loop to ensure POST bodies arriving in separate TCP segments are fully read
- Fix trace_api_calls symbol format from module.apiname to module!apiname matching x64dbg's DbgValFromString expected syntax
- Add /api/command endpoint (EXECUTE_COMMAND type 16) with handler for arbitrary x64dbg command execution via DbgCmdExec