### PR TITLE
style: replace excessive comment separators with clean single-line format & other 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Analyze the crash dump at C:\Windows\MEMORY.DMP
 Decompile the type MyNamespace.MyClass to C#
 ```
 
-## Capabilities
+## Capabilities (245 tools)
 
 ### Static Analysis (Ghidra) -- 35 tools
 
 Analysis, decompilation, cross-references, memory maps, byte pattern search, function renaming, call graphs, API pattern detection (100+ Windows APIs), crypto constant identification, IOC extraction, and binary compatibility checking.
 
-### Dynamic Analysis (x64dbg) -- 150+ tools
+### Dynamic Analysis (x64dbg) -- 159 tools
 
 | Category | What It Does |
 |----------|-------------|
@@ -103,13 +103,20 @@ Connection (KDNET, local kernel, crash dumps), execution control, breakpoints, r
 
 Type listing, C# decompilation, IL disassembly, type search, and full assembly decompilation.
 
-### Other
+### PE Structure (pefile) -- 1 tool
 
+Comprehensive PE header, section, import, export, resource, debug, TLS, and Rich header analysis in a single fast call (<500ms). Three detail levels (basic/standard/full) with decoded characteristic flags, compiler attribution, and malware indicators.
+
+### Other -- 23 tools
+
+- **Triage (3)** -- Quick file type detection, packer identification, entropy analysis
+- **Malware Analysis (4)** -- Behavior detection, threat chain identification, IOC extraction
+- **Control Flow (4)** -- CFG generation, cyclomatic complexity, loop detection, dead code
+- **Function Hashing (4)** -- Cross-binary function matching and similarity scoring
+- **VirusTotal (4)** -- Hash lookups, file submission, detection reports
 - **Session Management** -- Persistent analysis tracking across conversations
-- **Triage** -- Quick file type detection, packer identification, entropy analysis
-- **YARA** -- Rule scanning (optional `yara-python` dependency)
-- **Malware Analysis** -- Behavior detection, threat chain identification, IOC extraction
-- **Reporting** -- Generate structured analysis reports
+- **Reporting (2)** -- Generate structured analysis reports
+- **YARA (2)** -- Rule scanning (optional `yara-python` dependency)
 
 ## Supported Formats
 

--- a/src/engines/dynamic/windbg/bridge.py
+++ b/src/engines/dynamic/windbg/bridge.py
@@ -112,9 +112,7 @@ _BLOCKED_COMMANDS = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Debug trace — activate with WINDBG_DEBUG=1 to log all bridge calls to file
-# ---------------------------------------------------------------------------
+# --- Debug trace — activate with WINDBG_DEBUG=1 to log all bridge calls to file ---
 def _setup_debug_log() -> logging.Logger:
     """Configure file logging when WINDBG_DEBUG env var is set."""
     debug_logger = logging.getLogger("windbg.trace")
@@ -200,9 +198,7 @@ class WinDbgBridge(Debugger):
 
         logger.info("WinDbgBridge initialized (pybag=%s)", PYBAG_AVAILABLE)
 
-    # ------------------------------------------------------------------
-    # Debugger ABC implementation
-    # ------------------------------------------------------------------
+    # --- Debugger ABC implementation ---
 
     @_trace
     def connect(self, timeout: int = 10) -> bool:
@@ -434,9 +430,7 @@ class WinDbgBridge(Debugger):
             except Exception:
                 return {"address": "unavailable", "note": "register access limited in this mode"}
 
-    # ------------------------------------------------------------------
-    # Kernel-specific methods
-    # ------------------------------------------------------------------
+    # --- Kernel-specific methods ---
 
     @_trace
     def connect_kernel_net(self, port: int, key: str) -> bool:
@@ -681,9 +675,7 @@ class WinDbgBridge(Debugger):
         self._require_connected()
         return self.execute_command(f"!object {path}")
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+    # --- Internal helpers ---
 
     @staticmethod
     def _find_cdb() -> Path | None:

--- a/src/engines/dynamic/windbg/commands.py
+++ b/src/engines/dynamic/windbg/commands.py
@@ -124,9 +124,7 @@ class WinDbgCommands:
 
         return "\n".join(lines)
 
-    # ------------------------------------------------------------------
-    # Driver analysis workflows
-    # ------------------------------------------------------------------
+    # --- Driver analysis workflows ---
 
     def analyze_driver(self, driver_name: str) -> dict[str, Any]:
         """Full driver analysis: driver object, dispatch table, devices, IOCTLs.
@@ -266,9 +264,7 @@ class WinDbgCommands:
             "dispatch_handler_count": analysis["dispatch_handler_count"],
         }
 
-    # ------------------------------------------------------------------
-    # Crash dump workflows
-    # ------------------------------------------------------------------
+    # --- Crash dump workflows ---
 
     def analyze_crash_dump(self, dump_path: str) -> dict[str, Any]:
         """Full crash dump analysis with recommendations.
@@ -319,9 +315,7 @@ class WinDbgCommands:
             "recommendations": recommendations,
         }
 
-    # ------------------------------------------------------------------
-    # Cross-reference helpers
-    # ------------------------------------------------------------------
+    # --- Cross-reference helpers ---
 
     def compare_dispatch_tables(
         self, driver1: str, driver2: str

--- a/src/engines/dynamic/windbg/kernel_types.py
+++ b/src/engines/dynamic/windbg/kernel_types.py
@@ -122,9 +122,7 @@ class IRP:
     status: str | None = None
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
+# --- Internal helpers ---
 
 # Transfer method constants from the Windows DDK
 _METHOD_BUFFERED = 0

--- a/src/engines/dynamic/x64dbg/bridge.py
+++ b/src/engines/dynamic/x64dbg/bridge.py
@@ -724,7 +724,7 @@ class X64DbgBridge(Debugger):
         result = self._request("/api/breakpoint/list")
         return result.get("breakpoints", [])
 
-    # ── Exception handling control ──────────────────────────────────────
+    # --- Exception handling control ---
 
     _VALID_CHANCE_VALUES = ("first", "second", "all")
 
@@ -2043,7 +2043,7 @@ class X64DbgBridge(Debugger):
         result = self._request_with_retry("/api/command", {"command": command})
         return result
 
-    # ── Watch expression management ──────────────────────────────────
+    # --- Watch expression management ---
 
     _WATCHDOG_MODES = frozenset({
         "changed", "disabled", "unchanged",
@@ -2182,7 +2182,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Set watch {index} name to '{name.strip()}'")
         return result
 
-    # ── DLL breakpoint management ────────────────────────────────────
+    # --- DLL breakpoint management ---
 
     def set_dll_breakpoint(
         self, dll_name: str, singleshoot: bool = False
@@ -2506,9 +2506,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Deleted memory breakpoint at 0x{normalized_addr}")
         return True
 
-    # =========================================================================
-    # Wait/Synchronization Functions
-    # =========================================================================
+    # --- Wait/Synchronization Functions ---
 
     def wait_until_paused(self, timeout: int = 30000) -> dict[str, Any]:
         """
@@ -2603,9 +2601,7 @@ class X64DbgBridge(Debugger):
         self.run()
         return self.wait_until_paused(timeout=timeout)
 
-    # =========================================================================
-    # Event System
-    # =========================================================================
+    # --- Event System ---
 
     def get_events(self, max_events: int = 100, peek: bool = False) -> dict[str, Any]:
         """
@@ -2768,9 +2764,7 @@ class X64DbgBridge(Debugger):
                 "error": f"Timeout waiting for events: {event_types}"
             }
 
-    # =========================================================================
-    # Memory Allocation Functions (Phase 3)
-    # =========================================================================
+    # --- Memory Allocation Functions (Phase 3) ---
 
     def virt_alloc(self, size: int = 4096, address: str | None = None) -> dict[str, Any]:
         """
@@ -2913,9 +2907,7 @@ class X64DbgBridge(Debugger):
         result = self._request("/api/memory/check", data)
         return result.get("valid", False)
 
-    # =========================================================================
-    # Enhanced Breakpoint Functions (Phase 3)
-    # =========================================================================
+    # --- Enhanced Breakpoint Functions (Phase 3) ---
 
     def toggle_breakpoint(self, address: str, enable: bool = True) -> dict[str, Any]:
         """
@@ -3064,9 +3056,7 @@ class X64DbgBridge(Debugger):
         result = self._request("/api/breakpoint/list/all")
         return result
 
-    # =========================================================================
-    # Phase 4: Tracing & Analysis Functions
-    # =========================================================================
+    # --- Phase 4: Tracing & Analysis Functions ---
 
     def start_trace(
         self,
@@ -3215,9 +3205,7 @@ class X64DbgBridge(Debugger):
         """
         return self._request("/api/api_log/clear")
 
-    # =========================================================================
-    # Conditional Breakpoint with Logging
-    # =========================================================================
+    # --- Conditional Breakpoint with Logging ---
 
     def set_conditional_breakpoint(
         self,
@@ -3579,7 +3567,7 @@ class X64DbgBridge(Debugger):
         data = {"address": address}
         return self._request("/api/references", data)
 
-    # ── Advanced search commands ─────────────────────────────────────
+    # --- Advanced search commands ---
 
     def find_assembly(
         self, instruction: str, address: str = "", size: int = 0
@@ -3739,9 +3727,7 @@ class X64DbgBridge(Debugger):
         """
         return self._request("/api/callstack/detailed")
 
-    # =========================================================================
-    # Phase 5: Anti-Debug Bypass Functions
-    # =========================================================================
+    # --- Phase 5: Anti-Debug Bypass Functions ---
 
     def hide_debugger_peb(self) -> dict[str, Any]:
         """
@@ -3848,9 +3834,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Patched debug check at 0x{address}")
         return result
 
-    # =========================================================================
-    # Phase 6: Code Coverage Functions
-    # =========================================================================
+    # --- Phase 6: Code Coverage Functions ---
 
     def start_coverage(
         self,
@@ -3994,9 +3978,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Exported coverage to {file_path}")
         return result
 
-    # =========================================================================
-    # Module Dump with PE Reconstruction
-    # =========================================================================
+    # --- Module Dump with PE Reconstruction ---
 
     def dump_module(
         self,
@@ -4311,9 +4293,7 @@ class X64DbgBridge(Debugger):
         except Exception as e:
             result["warnings"].append(f"IAT rebuild failed: {e}")
 
-    # =========================================================================
-    # Memory Watch and Diff Functions
-    # =========================================================================
+    # --- Memory Watch and Diff Functions ---
 
     def watch_memory(
         self,
@@ -4709,9 +4689,7 @@ class X64DbgBridge(Debugger):
         else:
             return {"success": False, "error": f"Watch not found: {watch_id}"}
 
-    # =========================================================================
-    # API Hook Detection Methods
-    # =========================================================================
+    # --- API Hook Detection Methods ---
 
     def detect_hooks(
         self,
@@ -5284,7 +5262,7 @@ class X64DbgBridge(Debugger):
 
         return result
 
-    # ── Type system methods ─────────────────────────────────────────────
+    # --- Type system methods ---
 
     @staticmethod
     def _validate_type_name(name: str | None, param_name: str = "name") -> str:
@@ -5480,7 +5458,7 @@ class X64DbgBridge(Debugger):
         """
         return self._request_with_retry("/api/command", {"command": "ClearTypes"})
 
-    # ── Variable management ────────────────────────────────────────────
+    # --- Variable management ---
 
     def set_variable(self, name: str, value: str) -> dict[str, Any]:
         """
@@ -5554,7 +5532,7 @@ class X64DbgBridge(Debugger):
         logger.debug("Listed variables")
         return result
 
-    # ── GUI navigation ─────────────────────────────────────────────────
+    # --- GUI navigation ---
 
     def navigate_disasm(self, address: str) -> dict[str, Any]:
         """
@@ -5638,7 +5616,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Showed graph at {log_target}")
         return result
 
-    # ── Privilege management ───────────────────────────────────────────
+    # --- Privilege management ---
 
     def enable_privilege(self, name: str) -> dict[str, Any]:
         """
@@ -5694,7 +5672,7 @@ class X64DbgBridge(Debugger):
         logger.info(f"Disabled privilege: {name}")
         return result
 
-    # ── Conditional Tracing ──────────────────────────────────────────
+    # --- Conditional Tracing ---
 
     def set_trace_log(self, text: str, condition: str = "") -> dict[str, Any]:
         """

--- a/src/server.py
+++ b/src/server.py
@@ -1,7 +1,7 @@
 """
 Binary MCP Server for comprehensive binary analysis.
 
-Provides 50+ tools for static and dynamic binary analysis:
+Provides 245 tools for static and dynamic binary analysis:
 - Static analysis via Ghidra (headless mode) for native binaries
 - Static analysis via ILSpyCmd for .NET assemblies
 - Dynamic analysis via x64dbg (native plugin)

--- a/src/server.py
+++ b/src/server.py
@@ -29,6 +29,7 @@ from src.tools.dotnet_tools import register_dotnet_tools
 from src.tools.dynamic_tools import register_dynamic_tools
 from src.tools.function_hash_tools import register_function_hash_tools
 from src.tools.malware_tools import register_malware_tools
+from src.tools.pe_tools import register_pe_tools
 from src.tools.reporting import register_reporting_tools
 from src.tools.triage_tools import register_triage_tools
 from src.tools.vt_tools import register_vt_tools
@@ -2884,7 +2885,10 @@ def main():
     # Register function hash and cross-binary matching tools
     register_function_hash_tools(app, session_manager, cache, runner)
 
-    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash)")
+    # Register PE structure analysis tools
+    register_pe_tools(app, session_manager)
+
+    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash, PE structure)")
     logger.info(f"Session Directory: {session_manager.store_dir}")
 
     # Run the FastMCP server (handles stdio automatically)

--- a/src/server.py
+++ b/src/server.py
@@ -72,9 +72,7 @@ crypto_patterns = CryptoPatterns()
 compatibility_checker = BinaryCompatibilityChecker()
 
 
-# ============================================================================
-# HELPER FUNCTIONS
-# ============================================================================
+# --- Helper Functions ---
 
 def log_to_session(func=None, *, analysis_type: AnalysisType = AnalysisType.STATIC):
     """
@@ -442,9 +440,7 @@ def get_analysis_context(
         raise RuntimeError(f"Failed to analyze binary: {e}")
 
 
-# ============================================================================
-# PHASE 1: CORE TOOLS (P0 - Critical)
-# ============================================================================
+# --- Phase 1: Core Tools (P0 - Critical) ---
 
 @app.tool()
 @log_to_session
@@ -893,9 +889,7 @@ def decompile_function(
         return f"Error: {e}"
 
 
-# ============================================================================
-# PHASE 2: ENHANCED ANALYSIS TOOLS (P1 - Important)
-# ============================================================================
+# --- Phase 2: Enhanced Analysis Tools (P1 - Important) ---
 
 @app.tool()
 @log_to_session
@@ -1176,9 +1170,7 @@ def search_bytes(
         return f"Error: {e}"
 
 
-# ============================================================================
-# PHASE 3: ADVANCED TOOLS (P2 - Nice-to-have)
-# ============================================================================
+# --- Phase 3: Advanced Tools (P2 - Nice-To-Have) ---
 
 @app.tool()
 @log_to_session
@@ -1344,9 +1336,7 @@ def diagnose_setup() -> str:
         return f"Error: {e}"
 
 
-# ============================================================================
-# ADDITIONAL TOOLS
-# ============================================================================
+# --- Additional Tools ---
 
 @app.tool()
 def check_binary(binary_path: str) -> str:
@@ -1597,9 +1587,7 @@ def rename_function(
         return f"Error: {e}"
 
 
-# ============================================================================
-# ANALYSIS SESSION TOOLS
-# ============================================================================
+# --- Analysis Session Tools ---
 
 @app.tool()
 def start_analysis_session(
@@ -2206,9 +2194,7 @@ def get_active_session() -> str:
     return result
 
 
-# ============================================================================
-# CRYPTO ANALYSIS TOOLS
-# ============================================================================
+# --- Crypto Analysis Tools ---
 
 @app.tool()
 @log_to_session(analysis_type=AnalysisType.STATIC)
@@ -2570,9 +2556,7 @@ def decode_base64_file(
         return f"Error decoding file: {e}"
 
 
-# ============================================================================
-# PYTHON BYTECODE ANALYSIS TOOLS
-# ============================================================================
+# --- Python Bytecode Analysis Tools ---
 
 
 @app.tool()

--- a/src/tools/control_flow_tools.py
+++ b/src/tools/control_flow_tools.py
@@ -13,9 +13,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
+# --- Internal helpers ---
 
 
 def _get_or_run_analysis(binary_path: str, cache, runner) -> dict:
@@ -417,9 +415,7 @@ def _compute_nesting_depth(loops: list[dict]) -> dict[int, int]:
     return depths
 
 
-# ---------------------------------------------------------------------------
-# Public registration
-# ---------------------------------------------------------------------------
+# --- Public registration ---
 
 
 def register_control_flow_tools(app, session_manager=None, cache=None, runner=None):

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -1273,7 +1273,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_list_breakpoints failed: {e}")
             return f"Error: {e}"
 
-    # ── Exception handling control tools ────────────────────────────────
+    # --- Exception handling control tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -2486,7 +2486,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
                         "See FUTURE_FEATURES.md for implementation status.")
             return f"Error: {e}"
 
-    # ── Advanced search tools ────────────────────────────────────────
+    # --- Advanced search tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -4183,9 +4183,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
                 return ("Error: Anti-debug status requires C++ plugin implementation")
             return f"Error: {e}"
 
-    # =========================================================================
-    # Event System Tools
-    # =========================================================================
+    # --- Event System Tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -4376,9 +4374,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_run_until_event failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # Memory Allocation Tools (Phase 3)
-    # =========================================================================
+    # --- Memory Allocation Tools (Phase 3) ---
 
     @app.tool()
     @log_dynamic_tool
@@ -4597,9 +4593,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_check_memory failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # Enhanced Breakpoint Tools (Phase 3)
-    # =========================================================================
+    # --- Enhanced Breakpoint Tools (Phase 3) ---
 
     @app.tool()
     @log_dynamic_tool
@@ -4802,9 +4796,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_list_all_breakpoints failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # P2: Conditional Breakpoint Logging
-    # =========================================================================
+    # --- P2: Conditional Breakpoint Logging ---
 
     @app.tool()
     @log_dynamic_tool
@@ -5140,9 +5132,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_clear_breakpoint_logs failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # P2: Native Conditional Breakpoint with Logging (Enhanced)
-    # =========================================================================
+    # --- P2: Native Conditional Breakpoint with Logging (Enhanced) ---
 
     @app.tool()
     @log_dynamic_tool
@@ -5631,9 +5621,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_get_bp_logs failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # P2: Static/Dynamic Cross-Reference
-    # =========================================================================
+    # --- P2: Static/Dynamic Cross-Reference ---
 
     @app.tool()
     @log_dynamic_tool
@@ -6056,9 +6044,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_get_runtime_function_address failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # Static/Dynamic Cross-Reference (Ghidra Cache Integration)
-    # =========================================================================
+    # --- Static/Dynamic Cross-Reference (Ghidra Cache Integration) ---
 
     @app.tool()
     @log_dynamic_tool
@@ -6557,9 +6543,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_refresh_function_cache failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # P2: Session State Persistence
-    # =========================================================================
+    # --- P2: Session State Persistence ---
 
     @app.tool()
     @log_dynamic_tool
@@ -6957,9 +6941,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_delete_debug_state failed: {e}")
             return safe_error_message("Failed to delete debug state", e)
 
-    # =========================================================================
-    # P2: API Hook Detection
-    # =========================================================================
+    # --- P2: API Hook Detection ---
 
     @app.tool()
     @log_dynamic_tool
@@ -7331,9 +7313,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_unhook_function failed: {e}")
             return f"Error: {e}"
 
-    # =========================================================================
-    # P2: Memory Watch and Diff
-    # =========================================================================
+    # --- P2: Memory Watch and Diff ---
 
     @app.tool()
     @log_dynamic_tool
@@ -7937,7 +7917,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_delete_memory_watch failed: {e}")
             return f"Error: {e}"
 
-    # ── Watch expression tools ───────────────────────────────────────
+    # --- Watch expression tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8038,7 +8018,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_set_watchdog failed: {e}")
             return format_error_response(e, "set_watchdog")
 
-    # ── DLL breakpoint tools ─────────────────────────────────────────
+    # --- DLL breakpoint tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8297,7 +8277,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_get_exception_info failed: {e}")
             return f"Error: {e}"
 
-    # ── Variable management tools ─────────────────────────────────────
+    # --- Variable management tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8404,7 +8384,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_list_variables failed: {e}")
             return f"Error: {e}"
 
-    # ── GUI navigation tools ───────────────────────────────────────────
+    # --- GUI navigation tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8505,7 +8485,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_show_graph failed: {e}")
             return f"Error: {e}"
 
-    # ── Privilege management tools ─────────────────────────────────────
+    # --- Privilege management tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8574,7 +8554,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_disable_privilege failed: {e}")
             return f"Error: {e}"
 
-    # ── Type System Tools ──────────────────────────────────────────────
+    # --- Type System Tools ---
 
     @app.tool()
     @log_dynamic_tool
@@ -8914,7 +8894,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             logger.error(f"x64dbg_parse_types failed: {e}")
             return f"Error: {e}"
 
-    # ── Conditional Tracing Tools ───────────────────────────────────
+    # --- Conditional Tracing Tools ---
 
     @app.tool()
     @log_dynamic_tool

--- a/src/tools/malware_tools.py
+++ b/src/tools/malware_tools.py
@@ -14,9 +14,7 @@ import re
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Behavioral combination definitions
-# ---------------------------------------------------------------------------
+# --- Behavioral combination definitions ---
 
 BEHAVIOR_CATEGORIES = {
     "code_injection": {
@@ -240,9 +238,7 @@ BEHAVIOR_CATEGORIES = {
     },
 }
 
-# ---------------------------------------------------------------------------
-# API call chain definitions for threat pattern detection
-# ---------------------------------------------------------------------------
+# --- API call chain definitions for threat pattern detection ---
 
 API_CALL_CHAINS = [
     {
@@ -357,9 +353,7 @@ API_CALL_CHAINS = [
     },
 ]
 
-# ---------------------------------------------------------------------------
-# Anti-analysis definitions
-# ---------------------------------------------------------------------------
+# --- Anti-analysis definitions ---
 
 ANTI_ANALYSIS_CHECKS = {
     "anti_debug": {
@@ -461,9 +455,7 @@ ANTI_ANALYSIS_CHECKS = {
     },
 }
 
-# ---------------------------------------------------------------------------
-# IOC regex patterns
-# ---------------------------------------------------------------------------
+# --- IOC regex patterns ---
 
 IOC_PATTERNS = {
     "ipv4": {
@@ -540,9 +532,7 @@ for _ioc_type, _ioc_def in IOC_PATTERNS.items():
     }
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
+# --- Internal helpers ---
 
 def _get_import_names(context: dict) -> set[str]:
     """Extract set of imported API names from cached analysis context."""
@@ -657,9 +647,7 @@ def _severity_rank(sev: str) -> int:
     return {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}.get(sev, 5)
 
 
-# ---------------------------------------------------------------------------
-# Registration
-# ---------------------------------------------------------------------------
+# --- Registration ---
 
 def register_malware_tools(app, session_manager, cache, runner, api_patterns):
     """

--- a/src/tools/pe_tools.py
+++ b/src/tools/pe_tools.py
@@ -1,0 +1,726 @@
+"""
+PE structure analysis tools.
+
+Provides comprehensive PE file structure parsing using pefile,
+returning complete header, section, import, export, resource,
+and metadata information in a single fast tool call.
+"""
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# --- Lookup Tables ---
+
+MACHINE_TYPES = {
+    0x0: "Unknown",
+    0x014C: "x86 (i386)",
+    0x0166: "MIPS R4000",
+    0x0169: "MIPS R10000",
+    0x01A2: "Hitachi SH3",
+    0x01A3: "Hitachi SH3 DSP",
+    0x01C0: "ARM",
+    0x01C4: "ARMv7 (Thumb-2)",
+    0x01F0: "PowerPC",
+    0x0200: "IA-64 (Itanium)",
+    0x0266: "MIPS16",
+    0x5032: "RISC-V 32-bit",
+    0x5064: "RISC-V 64-bit",
+    0x8664: "x64 (AMD64)",
+    0xAA64: "ARM64 (AArch64)",
+}
+
+SUBSYSTEM_NAMES = {
+    0: "Unknown",
+    1: "Native",
+    2: "Windows GUI",
+    3: "Windows Console",
+    5: "OS/2 Console",
+    7: "POSIX Console",
+    9: "Windows CE",
+    10: "EFI Application",
+    11: "EFI Boot Driver",
+    12: "EFI Runtime Driver",
+    13: "EFI ROM",
+    14: "Xbox",
+    16: "Windows Boot",
+}
+
+FILE_CHARACTERISTICS = {
+    0x0001: "RELOCS_STRIPPED",
+    0x0002: "EXECUTABLE_IMAGE",
+    0x0004: "LINE_NUMS_STRIPPED",
+    0x0008: "LOCAL_SYMS_STRIPPED",
+    0x0020: "LARGE_ADDRESS_AWARE",
+    0x0100: "32BIT_MACHINE",
+    0x0200: "DEBUG_STRIPPED",
+    0x0400: "REMOVABLE_RUN_FROM_SWAP",
+    0x0800: "NET_RUN_FROM_SWAP",
+    0x1000: "SYSTEM",
+    0x2000: "DLL",
+    0x4000: "UP_SYSTEM_ONLY",
+}
+
+DLL_CHARACTERISTICS = {
+    0x0020: "HIGH_ENTROPY_VA",
+    0x0040: "DYNAMIC_BASE (ASLR)",
+    0x0080: "FORCE_INTEGRITY",
+    0x0100: "NX_COMPAT (DEP)",
+    0x0200: "NO_ISOLATION",
+    0x0400: "NO_SEH",
+    0x0800: "NO_BIND",
+    0x1000: "APPCONTAINER",
+    0x2000: "WDM_DRIVER",
+    0x4000: "GUARD_CF",
+    0x8000: "TERMINAL_SERVER_AWARE",
+}
+
+SECTION_CHARACTERISTICS = {
+    0x00000020: "CODE",
+    0x00000040: "INITIALIZED_DATA",
+    0x00000080: "UNINITIALIZED_DATA",
+    0x02000000: "DISCARDABLE",
+    0x04000000: "NOT_CACHED",
+    0x08000000: "NOT_PAGED",
+    0x10000000: "SHARED",
+    0x20000000: "EXECUTE",
+    0x40000000: "READ",
+    0x80000000: "WRITE",
+}
+
+DATA_DIRECTORY_NAMES = [
+    "Export", "Import", "Resource", "Exception",
+    "Security", "Relocation", "Debug", "Architecture",
+    "GlobalPtr", "TLS", "Load Config", "Bound Import",
+    "IAT", "Delay Import", "CLR Runtime", "Reserved",
+]
+
+# Known Rich header tool IDs (comp.id >> 16) mapped to compiler/linker names
+RICH_TOOL_IDS = {
+    0x0001: "Import0",
+    0x0004: "Linker",
+    0x0006: "CVTOMF",
+    0x0007: "Export",
+    0x000A: "Assembler (MASM)",
+    0x000F: "Linker",
+    0x0019: "Import",
+    0x001C: "Resource Compiler",
+    0x005D: "Utc1310 (VS2003 C/C++)",
+    0x006D: "Utc1400 (VS2005 C/C++)",
+    0x0078: "Utc1400 (VS2005 C++)",
+    0x0083: "Utc1500 (VS2008 C/C++)",
+    0x0093: "Utc1600 (VS2010 C/C++)",
+    0x00AA: "Utc1700 (VS2012 C/C++)",
+    0x00AB: "Utc1700 (VS2012 C++)",
+    0x00C7: "Utc1800 (VS2013 C/C++)",
+    0x00C8: "Utc1800 (VS2013 C++)",
+    0x00D9: "Utc1900 (VS2015 C/C++)",
+    0x00DA: "Utc1900 (VS2015 C++)",
+    0x00E0: "Resource Compiler (VS2015)",
+    0x0104: "Utc1910 (VS2017 C/C++)",
+    0x0105: "Utc1910 (VS2017 C++)",
+    0x010E: "Linker (VS2017)",
+    0x0112: "Utc1920 (VS2019 C/C++)",
+    0x0113: "Utc1920 (VS2019 C++)",
+    0x0116: "Linker (VS2019)",
+    0x0120: "Utc1930 (VS2022 C/C++)",
+    0x0121: "Utc1930 (VS2022 C++)",
+    0x0124: "Linker (VS2022)",
+}
+
+
+# --- Helper Functions ---
+
+def _format_flags(value: int, flag_map: dict) -> list[str]:
+    """Decode a bitfield into a list of human-readable flag names."""
+    return [name for bit, name in sorted(flag_map.items()) if value & bit]
+
+
+def _format_timestamp(timestamp: int) -> str:
+    """Convert PE timestamp to readable UTC string."""
+    if timestamp == 0:
+        return "Not set"
+    if timestamp == 0xFFFFFFFF:
+        return "Invalid (0xFFFFFFFF)"
+    try:
+        dt = datetime.fromtimestamp(timestamp, tz=UTC)
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+    except (OSError, ValueError, OverflowError):
+        return f"Invalid (0x{timestamp:08X})"
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format byte count as human-readable string."""
+    if size_bytes < 1024:
+        return f"{size_bytes:,} bytes"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes:,} bytes ({size_bytes / 1024:.1f} KB)"
+    else:
+        return f"{size_bytes:,} bytes ({size_bytes / (1024 * 1024):.1f} MB)"
+
+
+def _section_table(pe) -> list[str]:
+    """Format the section table with entropy and decoded flags."""
+    lines = [f"--- Sections ({len(pe.sections)}) ---"]
+    lines.append(f"  {'Name':<10} {'VirtAddr':<10} {'VirtSize':<10} {'RawSize':<10} {'Entropy':<8} Flags")
+    for section in pe.sections:
+        name = section.Name.decode("utf-8", errors="ignore").rstrip("\x00")
+        entropy = section.get_entropy()
+        flags = ", ".join(_format_flags(section.Characteristics, SECTION_CHARACTERISTICS))
+        lines.append(
+            f"  {name:<10} 0x{section.VirtualAddress:<8X} 0x{section.Misc_VirtualSize:<8X} "
+            f"0x{section.SizeOfRawData:<8X} {entropy:<8.2f} {flags}"
+        )
+    return lines
+
+
+def _parse_imports(pe) -> list[str]:
+    """Parse and format the import table."""
+    lines = []
+    if not hasattr(pe, "DIRECTORY_ENTRY_IMPORT") or not pe.DIRECTORY_ENTRY_IMPORT:
+        lines.append("--- Imports ---")
+        lines.append("No imports")
+        return lines
+
+    total_funcs = sum(len(entry.imports) for entry in pe.DIRECTORY_ENTRY_IMPORT)
+    num_dlls = len(pe.DIRECTORY_ENTRY_IMPORT)
+    lines.append(f"--- Imports ({num_dlls} DLLs, {total_funcs} functions) ---")
+
+    for entry in pe.DIRECTORY_ENTRY_IMPORT:
+        dll_name = entry.dll.decode("utf-8", errors="ignore") if entry.dll else "Unknown"
+        func_names = []
+        for imp in entry.imports:
+            if imp.name:
+                func_names.append(imp.name.decode("utf-8", errors="ignore"))
+            elif imp.ordinal:
+                func_names.append(f"ord({imp.ordinal})")
+        lines.append(f"{dll_name} ({len(func_names)}):")
+        # Wrap function names at ~80 chars per line
+        line = "  "
+        for i, name in enumerate(func_names):
+            separator = ", " if i > 0 else ""
+            if len(line) + len(separator) + len(name) > 100:
+                lines.append(line)
+                line = "  " + name
+            else:
+                line += separator + name
+        if line.strip():
+            lines.append(line)
+
+    return lines
+
+
+def _parse_exports(pe) -> list[str]:
+    """Parse and format the export table."""
+    lines = ["--- Exports ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_EXPORT") or not pe.DIRECTORY_ENTRY_EXPORT:
+        lines.append("No exports")
+        return lines
+
+    symbols = pe.DIRECTORY_ENTRY_EXPORT.symbols
+    dll_name = ""
+    if pe.DIRECTORY_ENTRY_EXPORT.name:
+        dll_name = pe.DIRECTORY_ENTRY_EXPORT.name.decode("utf-8", errors="ignore")
+        lines.append(f"DLL Name: {dll_name}")
+    lines.append(f"Total: {len(symbols)} exports")
+
+    for sym in symbols[:200]:  # Cap at 200 for readability
+        name = sym.name.decode("utf-8", errors="ignore") if sym.name else None
+        fwd = sym.forwarder.decode("utf-8", errors="ignore") if sym.forwarder else None
+        if fwd:
+            lines.append(f"  ord({sym.ordinal}) {name or ''} -> {fwd}")
+        elif name:
+            lines.append(f"  ord({sym.ordinal}) {name} @ 0x{sym.address:X}")
+        else:
+            lines.append(f"  ord({sym.ordinal}) @ 0x{sym.address:X}")
+    if len(symbols) > 200:
+        lines.append(f"  ... and {len(symbols) - 200} more")
+
+    return lines
+
+
+def _parse_resources(pe) -> list[str]:
+    """Parse resources: version info strings and resource type summary."""
+    lines = ["--- Resources ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_RESOURCE") or not pe.DIRECTORY_ENTRY_RESOURCE:
+        lines.append("No resources")
+        return lines
+
+    # Version info extraction
+    version_info = {}
+    if hasattr(pe, "FileInfo"):
+        try:
+            for file_info_list in pe.FileInfo:
+                for entry in file_info_list:
+                    if hasattr(entry, "StringTable"):
+                        for st in entry.StringTable:
+                            for key, value in st.entries.items():
+                                k = key.decode("utf-8", errors="ignore") if isinstance(key, bytes) else str(key)
+                                v = value.decode("utf-8", errors="ignore") if isinstance(value, bytes) else str(value)
+                                if v.strip():
+                                    version_info[k] = v
+        except (AttributeError, TypeError):
+            pass
+
+    if version_info:
+        lines.append("Version Info:")
+        # Show common fields in a logical order
+        priority_keys = [
+            "CompanyName", "ProductName", "FileDescription",
+            "FileVersion", "ProductVersion", "OriginalFilename",
+            "InternalName", "LegalCopyright",
+        ]
+        shown = set()
+        for key in priority_keys:
+            if key in version_info:
+                lines.append(f"  {key}: {version_info[key]}")
+                shown.add(key)
+        for key, value in version_info.items():
+            if key not in shown:
+                lines.append(f"  {key}: {value}")
+
+    # Resource type summary
+    import pefile as _pefile
+    type_counts: dict[str, int] = {}
+    for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+        if entry.id is not None:
+            type_name = _pefile.RESOURCE_TYPE.get(entry.id, f"Unknown({entry.id})")
+        elif entry.name:
+            type_name = str(entry.name)
+        else:
+            type_name = "Unknown"
+
+        count = 0
+        if hasattr(entry, "directory") and entry.directory:
+            count = len(entry.directory.entries)
+        else:
+            count = 1
+        type_counts[type_name] = type_counts.get(type_name, 0) + count
+
+    if type_counts:
+        summary = ", ".join(f"{name} ({count})" for name, count in sorted(type_counts.items()))
+        lines.append(f"Resource Types: {summary}")
+
+    return lines
+
+
+def _parse_debug_info(pe) -> list[str]:
+    """Parse debug directory for PDB path and debug type."""
+    lines = ["--- Debug Info ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_DEBUG") or not pe.DIRECTORY_ENTRY_DEBUG:
+        lines.append("No debug info")
+        return lines
+
+    debug_type_names = {
+        0: "Unknown", 1: "COFF", 2: "CodeView", 3: "FPO",
+        4: "Misc", 5: "Exception", 6: "Fixup", 9: "Borland",
+        10: "BBT", 11: "Clsid", 12: "VC Feature", 13: "POGO",
+        14: "ILTCG", 16: "Repro", 17: "Embedded",
+    }
+
+    for debug_entry in pe.DIRECTORY_ENTRY_DEBUG:
+        dtype = debug_type_names.get(debug_entry.struct.Type, f"Type({debug_entry.struct.Type})")
+        lines.append(f"Type: {dtype}")
+        lines.append(f"Timestamp: {_format_timestamp(debug_entry.struct.TimeDateStamp)}")
+
+        # Extract PDB path from CodeView entries
+        if debug_entry.struct.Type == 2 and hasattr(debug_entry, "entry") and debug_entry.entry:
+            entry = debug_entry.entry
+            if hasattr(entry, "PdbFileName"):
+                pdb = entry.PdbFileName
+                if isinstance(pdb, bytes):
+                    pdb = pdb.decode("utf-8", errors="ignore").rstrip("\x00")
+                lines.append(f"PDB Path: {pdb}")
+            if hasattr(entry, "Signature_String"):
+                lines.append(f"GUID: {entry.Signature_String}")
+
+    return lines
+
+
+def _parse_tls(pe) -> list[str]:
+    """Parse TLS directory for callback addresses."""
+    lines = ["--- TLS ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_TLS") or not pe.DIRECTORY_ENTRY_TLS:
+        lines.append("No TLS directory")
+        return lines
+
+    tls = pe.DIRECTORY_ENTRY_TLS.struct
+    lines.append(f"Raw Data: 0x{tls.StartAddressOfRawData:X} - 0x{tls.EndAddressOfRawData:X}")
+    lines.append(f"Index Address: 0x{tls.AddressOfIndex:X}")
+    lines.append(f"Callbacks Address: 0x{tls.AddressOfCallBacks:X}")
+
+    # Read callback table
+    if tls.AddressOfCallBacks:
+        callbacks = []
+        try:
+            pointer_size = 8 if pe.OPTIONAL_HEADER.Magic == 0x20B else 4
+            callback_rva = tls.AddressOfCallBacks - pe.OPTIONAL_HEADER.ImageBase
+            for i in range(32):  # Safety limit
+                data = pe.get_data(callback_rva + i * pointer_size, pointer_size)
+                if pointer_size == 8:
+                    addr = int.from_bytes(data, "little")
+                else:
+                    addr = int.from_bytes(data, "little")
+                if addr == 0:
+                    break
+                callbacks.append(addr)
+        except Exception:
+            pass
+
+        if callbacks:
+            lines.append(f"TLS Callbacks: {len(callbacks)} found (malware indicator!)")
+            for addr in callbacks:
+                lines.append(f"  0x{addr:X}")
+        else:
+            lines.append("TLS Callbacks: None")
+
+    return lines
+
+
+def _parse_rich_header(pe) -> list[str]:
+    """Parse Rich header for compiler/linker metadata."""
+    lines = ["--- Rich Header ---"]
+    if not hasattr(pe, "RICH_HEADER") or not pe.RICH_HEADER:
+        lines.append("No Rich header")
+        return lines
+
+    lines.append(f"{'Tool':<35} {'Build':<10} Count")
+    for comp_id, count in pe.RICH_HEADER.values:
+        tool_id = comp_id >> 16
+        build = comp_id & 0xFFFF
+        tool_name = RICH_TOOL_IDS.get(tool_id, f"Unknown (0x{tool_id:04X})")
+        lines.append(f"  {tool_name:<33} {build:<10} {count}")
+
+    return lines
+
+
+def _parse_relocations(pe) -> list[str]:
+    """Parse base relocations (full detail only)."""
+    lines = ["--- Relocations ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_BASERELOC") or not pe.DIRECTORY_ENTRY_BASERELOC:
+        lines.append("No relocations")
+        return lines
+
+    total = sum(len(block.entries) for block in pe.DIRECTORY_ENTRY_BASERELOC)
+    lines.append(f"Total: {total} relocations across {len(pe.DIRECTORY_ENTRY_BASERELOC)} blocks")
+    return lines
+
+
+def _parse_delay_imports(pe) -> list[str]:
+    """Parse delay import directory (full detail only)."""
+    lines = ["--- Delay Imports ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_DELAY_IMPORT") or not pe.DIRECTORY_ENTRY_DELAY_IMPORT:
+        lines.append("No delay imports")
+        return lines
+
+    for entry in pe.DIRECTORY_ENTRY_DELAY_IMPORT:
+        dll_name = entry.dll.decode("utf-8", errors="ignore") if entry.dll else "Unknown"
+        func_count = len(entry.imports)
+        func_names = []
+        for imp in entry.imports:
+            if imp.name:
+                func_names.append(imp.name.decode("utf-8", errors="ignore"))
+            elif imp.ordinal:
+                func_names.append(f"ord({imp.ordinal})")
+        lines.append(f"{dll_name} ({func_count}): {', '.join(func_names)}")
+
+    return lines
+
+
+def _parse_load_config(pe) -> list[str]:
+    """Parse load configuration directory (full detail only)."""
+    lines = ["--- Load Config ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_LOAD_CONFIG") or not pe.DIRECTORY_ENTRY_LOAD_CONFIG:
+        lines.append("No load config")
+        return lines
+
+    lc = pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct
+    if hasattr(lc, "SecurityCookie"):
+        lines.append(f"Security Cookie: 0x{lc.SecurityCookie:X}")
+    if hasattr(lc, "GuardCFCheckFunctionPointer") and lc.GuardCFCheckFunctionPointer:
+        lines.append(f"Guard CF Check: 0x{lc.GuardCFCheckFunctionPointer:X}")
+    if hasattr(lc, "GuardCFFunctionCount"):
+        lines.append(f"Guard CF Function Count: {lc.GuardCFFunctionCount}")
+    if hasattr(lc, "GuardFlags") and lc.GuardFlags:
+        lines.append(f"Guard Flags: 0x{lc.GuardFlags:X}")
+
+    return lines
+
+
+def _parse_bound_imports(pe) -> list[str]:
+    """Parse bound import directory (full detail only)."""
+    lines = ["--- Bound Imports ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_BOUND_IMPORT") or not pe.DIRECTORY_ENTRY_BOUND_IMPORT:
+        lines.append("No bound imports")
+        return lines
+
+    for entry in pe.DIRECTORY_ENTRY_BOUND_IMPORT:
+        name = entry.name.decode("utf-8", errors="ignore") if entry.name else "Unknown"
+        ts = _format_timestamp(entry.struct.TimeDateStamp)
+        lines.append(f"  {name} (bound: {ts})")
+
+    return lines
+
+
+def _parse_exceptions(pe) -> list[str]:
+    """Parse exception directory — x64 RUNTIME_FUNCTION entries (full detail only)."""
+    lines = ["--- Exception Handlers ---"]
+    if not hasattr(pe, "DIRECTORY_ENTRY_EXCEPTION") or not pe.DIRECTORY_ENTRY_EXCEPTION:
+        lines.append("No exception directory")
+        return lines
+
+    lines.append(f"RUNTIME_FUNCTION entries: {len(pe.DIRECTORY_ENTRY_EXCEPTION)}")
+    return lines
+
+
+def _detect_overlay(pe, file_path: Path, include_hex: bool = False) -> list[str]:
+    """Detect overlay data appended after PE structure."""
+    lines = ["--- Overlay ---"]
+    try:
+        offset = pe.get_overlay_data_start_offset()
+        if offset is None:
+            lines.append("No overlay")
+            return lines
+
+        file_size = file_path.stat().st_size
+        overlay_size = file_size - offset
+        if overlay_size <= 0:
+            lines.append("No overlay")
+            return lines
+
+        lines.append(f"Offset: 0x{offset:X}")
+        lines.append(f"Size: {_format_size(overlay_size)}")
+
+        if include_hex and overlay_size > 0:
+            data = file_path.read_bytes()[offset:offset + 256]
+            hex_lines = []
+            for i in range(0, len(data), 16):
+                chunk = data[i:i + 16]
+                hex_part = " ".join(f"{b:02X}" for b in chunk)
+                ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+                hex_lines.append(f"  {offset + i:08X}: {hex_part:<48} {ascii_part}")
+            lines.append("First 256 bytes:")
+            lines.extend(hex_lines)
+    except Exception:
+        lines.append("Could not determine overlay")
+
+    return lines
+
+
+# --- Registration ---
+
+def register_pe_tools(app, session_manager=None):
+    """Register PE structure analysis tools with the MCP app."""
+    from src.utils.security import (
+        FileSizeError,
+        PathTraversalError,
+        safe_error_message,
+        sanitize_binary_path,
+    )
+
+    @app.tool()
+    def get_pe_info(binary_path: str, detail_level: str = "standard") -> str:
+        """
+        Get comprehensive PE file structure information.
+
+        Returns complete PE headers, sections, imports, exports, resources,
+        debug info, TLS, Rich header, and more — all from a single fast call
+        using pefile (no Ghidra dependency).
+
+        Args:
+            binary_path: Path to the PE file to analyze
+            detail_level: Level of detail - "basic", "standard", or "full"
+                - basic: Headers, sections, data directory summary (~50ms)
+                - standard: + imports, exports, resources, debug, TLS,
+                  Rich header, imphash, section hashes (~200ms)
+                - full: + relocations, delay imports, load config,
+                  exceptions, overlay hex dump, PE warnings (~500ms)
+
+        Returns:
+            Formatted PE structure analysis
+
+        Example:
+            get_pe_info("/path/to/malware.exe")
+            get_pe_info("/path/to/sample.dll", detail_level="full")
+        """
+        try:
+            binary_path = sanitize_binary_path(binary_path)
+            path = Path(binary_path)
+
+            if detail_level not in ("basic", "standard", "full"):
+                return (
+                    f"Invalid detail_level '{detail_level}'. "
+                    "Must be one of: basic, standard, full"
+                )
+
+            import pefile
+
+            try:
+                pe = pefile.PE(str(path), fast_load=True)
+            except pefile.PEFormatError as e:
+                return f"Not a valid PE file: {e}"
+
+            try:
+                file_size = path.stat().st_size
+                output: list[str] = []
+
+                output.append("PE Structure Analysis")
+                output.append(f"File: {path.name}")
+                output.append(f"Size: {_format_size(file_size)}")
+                output.append(f"Detail: {detail_level}")
+                output.append("")
+
+                # --- Headers (always) ---
+                output.append("--- Headers ---")
+                machine = MACHINE_TYPES.get(
+                    pe.FILE_HEADER.Machine,
+                    f"Unknown (0x{pe.FILE_HEADER.Machine:04X})",
+                )
+                output.append(f"Machine: {machine}")
+                output.append(f"Sections: {pe.FILE_HEADER.NumberOfSections}")
+                output.append(f"Compile Time: {_format_timestamp(pe.FILE_HEADER.TimeDateStamp)}")
+                chars = _format_flags(pe.FILE_HEADER.Characteristics, FILE_CHARACTERISTICS)
+                output.append(f"Characteristics: {', '.join(chars) if chars else 'None'}")
+                magic = "PE32+" if pe.OPTIONAL_HEADER.Magic == 0x20B else "PE32"
+                output.append(f"Format: {magic}")
+                output.append(f"ImageBase: 0x{pe.OPTIONAL_HEADER.ImageBase:X}")
+                output.append(f"EntryPoint: 0x{pe.OPTIONAL_HEADER.AddressOfEntryPoint:X}")
+                subsys = SUBSYSTEM_NAMES.get(pe.OPTIONAL_HEADER.Subsystem, "Unknown")
+                output.append(f"Subsystem: {subsys}")
+                dll_chars = _format_flags(pe.OPTIONAL_HEADER.DllCharacteristics, DLL_CHARACTERISTICS)
+                output.append(f"DllCharacteristics: {', '.join(dll_chars) if dll_chars else 'None'}")
+                output.append(f"SectionAlignment: 0x{pe.OPTIONAL_HEADER.SectionAlignment:X}")
+                output.append(f"FileAlignment: 0x{pe.OPTIONAL_HEADER.FileAlignment:X}")
+                output.append(f"SizeOfImage: 0x{pe.OPTIONAL_HEADER.SizeOfImage:X}")
+                output.append(f"SizeOfHeaders: 0x{pe.OPTIONAL_HEADER.SizeOfHeaders:X}")
+
+                is_dll = bool(pe.FILE_HEADER.Characteristics & 0x2000)
+                is_driver = pe.OPTIONAL_HEADER.Subsystem == 1
+                pe_type = "DLL" if is_dll else "Driver" if is_driver else "EXE"
+                output.append(f"Type: {pe_type}")
+                output.append("")
+
+                # --- Section Table (always) ---
+                output.extend(_section_table(pe))
+                output.append("")
+
+                # --- Data Directory Summary (always) ---
+                output.append("--- Data Directories ---")
+                for i, name in enumerate(DATA_DIRECTORY_NAMES):
+                    if i < len(pe.OPTIONAL_HEADER.DATA_DIRECTORY):
+                        dd = pe.OPTIONAL_HEADER.DATA_DIRECTORY[i]
+                        if dd.VirtualAddress != 0:
+                            output.append(f"  {name}: RVA=0x{dd.VirtualAddress:X}, Size=0x{dd.Size:X}")
+                output.append("")
+
+                # --- Overlay (always) ---
+                output.extend(_detect_overlay(pe, path, include_hex=(detail_level == "full")))
+                output.append("")
+
+                # --- Standard + Full: parse data directories ---
+                if detail_level in ("standard", "full"):
+                    dirs_to_parse = [
+                        pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"],
+                        pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_EXPORT"],
+                        pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"],
+                        pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DEBUG"],
+                        pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_TLS"],
+                    ]
+                    if detail_level == "full":
+                        dirs_to_parse.extend([
+                            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_BASERELOC"],
+                            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT"],
+                            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG"],
+                            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT"],
+                            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_EXCEPTION"],
+                        ])
+
+                    try:
+                        pe.parse_data_directories(directories=dirs_to_parse)
+                    except Exception as e:
+                        output.append(f"Warning: Partial directory parse failure: {e}")
+                        output.append("")
+
+                    output.extend(_parse_imports(pe))
+                    output.append("")
+                    output.extend(_parse_exports(pe))
+                    output.append("")
+                    output.extend(_parse_resources(pe))
+                    output.append("")
+                    output.extend(_parse_debug_info(pe))
+                    output.append("")
+                    output.extend(_parse_tls(pe))
+                    output.append("")
+                    output.extend(_parse_rich_header(pe))
+                    output.append("")
+
+                    # Section hashes
+                    output.append("--- Section Hashes ---")
+                    for section in pe.sections:
+                        name = section.Name.decode("utf-8", errors="ignore").rstrip("\x00")
+                        try:
+                            data = section.get_data()
+                            md5 = hashlib.md5(data).hexdigest()  # noqa: S324
+                            line = f"  {name}: MD5={md5}"
+                            if detail_level == "full":
+                                sha256 = hashlib.sha256(data).hexdigest()
+                                line += f", SHA256={sha256}"
+                            output.append(line)
+                        except Exception:
+                            output.append(f"  {name}: (could not read)")
+                    output.append("")
+
+                    # Imphash
+                    try:
+                        imphash = pe.get_imphash()
+                        if imphash:
+                            output.append(f"Imphash: {imphash}")
+                            output.append("")
+                    except Exception:
+                        pass
+
+                # --- Full only ---
+                if detail_level == "full":
+                    output.extend(_parse_relocations(pe))
+                    output.append("")
+                    output.extend(_parse_delay_imports(pe))
+                    output.append("")
+                    output.extend(_parse_load_config(pe))
+                    output.append("")
+                    output.extend(_parse_bound_imports(pe))
+                    output.append("")
+                    output.extend(_parse_exceptions(pe))
+                    output.append("")
+
+                    # Rich header hash
+                    if hasattr(pe, "RICH_HEADER") and pe.RICH_HEADER:
+                        try:
+                            rich_hash = hashlib.md5(pe.RICH_HEADER.raw_data).hexdigest()  # noqa: S324
+                            output.append(f"Rich Header Hash: {rich_hash}")
+                            output.append("")
+                        except Exception:
+                            pass
+
+                    # PE parser warnings
+                    warnings = pe.get_warnings()
+                    if warnings:
+                        output.append("--- PE Parser Warnings ---")
+                        for w in warnings:
+                            output.append(f"  {w}")
+                        output.append("")
+
+                return "\n".join(output)
+
+            finally:
+                pe.close()
+
+        except (PathTraversalError, FileSizeError) as e:
+            return safe_error_message("get_pe_info", e)
+        except Exception as e:
+            logger.error(f"get_pe_info failed: {e}")
+            return safe_error_message("Failed to analyze PE file", e)
+
+    logger.info("Registered 1 PE structure tools")

--- a/src/tools/windbg_tools.py
+++ b/src/tools/windbg_tools.py
@@ -38,9 +38,7 @@ def _is_windows() -> bool:
     return platform.system() == "Windows"
 
 
-# ---------------------------------------------------------------------------
-# Input validation helpers for command-injection prevention
-# ---------------------------------------------------------------------------
+# --- Input validation helpers for command-injection prevention ---
 
 _SAFE_ADDRESS_RE = re.compile(r'^[0-9a-fA-F`x]+$')  # Hex addresses with optional backticks and 0x prefix
 _SAFE_SYMBOL_RE = re.compile(r'^[a-zA-Z0-9_!.*+:]+$')  # Symbol names like nt!NtCreateFile or module!*
@@ -125,9 +123,7 @@ def register_windbg_tools(
     global _session_manager
     _session_manager = session_manager
 
-    # ------------------------------------------------------------------
-    # Connection tools (4)
-    # ------------------------------------------------------------------
+    # --- Connection tools (4) ---
 
     @app.tool()
     @log_windbg_tool
@@ -216,9 +212,7 @@ def register_windbg_tools(
         except Exception as e:
             return f"Error: {e}"
 
-    # ------------------------------------------------------------------
-    # Execution tools (6)
-    # ------------------------------------------------------------------
+    # --- Execution tools (6) ---
 
     @app.tool()
     @log_windbg_tool
@@ -348,9 +342,7 @@ def register_windbg_tools(
         except (WinDbgBridgeError, StructuredBaseError) as e:
             return f"Error: {e}"
 
-    # ------------------------------------------------------------------
-    # Breakpoint tools (4)
-    # ------------------------------------------------------------------
+    # --- Breakpoint tools (4) ---
 
     @app.tool()
     @log_windbg_tool
@@ -434,9 +426,7 @@ def register_windbg_tools(
         except (WinDbgBridgeError, StructuredBaseError) as e:
             return f"Error: {e}"
 
-    # ------------------------------------------------------------------
-    # Inspection tools (6)
-    # ------------------------------------------------------------------
+    # --- Inspection tools (6) ---
 
     @app.tool()
     @log_windbg_tool

--- a/src/utils/structured_errors.py
+++ b/src/utils/structured_errors.py
@@ -176,9 +176,7 @@ class StructuredBaseError(Exception):
         return self.structured_error.to_json(indent)
 
 
-# =============================================================================
-# Suggestion Mappings - Predefined suggestions for common error scenarios
-# =============================================================================
+# --- Suggestion Mappings - Predefined Suggestions For Common Error Scenarios ---
 
 BREAKPOINT_SUGGESTIONS = {
     "address_invalid": [
@@ -331,9 +329,7 @@ WINDBG_SUGGESTIONS = {
 }
 
 
-# =============================================================================
-# Error Factory Functions
-# =============================================================================
+# --- Error Factory Functions ---
 
 
 def create_address_invalid_error(
@@ -677,9 +673,7 @@ def create_parameter_error(
     )
 
 
-# =============================================================================
-# Kernel / WinDbg Error Factory Functions
-# =============================================================================
+# --- Kernel / Windbg Error Factory Functions ---
 
 
 def create_windbg_not_found_error(
@@ -754,9 +748,7 @@ def create_windbg_command_failed_error(
     )
 
 
-# =============================================================================
-# Error Classification Helpers
-# =============================================================================
+# --- Error Classification Helpers ---
 
 
 def classify_api_error(api_message: str, operation: str = "") -> ErrorCode:


### PR DESCRIPTION
Replace three-line separator blocks (===, ---, ──) with a consistent single-line `# --- Section Name ---` format across all source files. Removes 108 lines of decorative comment noise while preserving section organization. String literals and markdown output formatting unchanged.Add any other context about the pull request here.

And other general changes. 