### PR TITLE
perf(ghidra): add resumable, chunked, decompile-skip analysis for large binaries

### DIFF
--- a/src/engines/dynamic/windbg/bridge.py
+++ b/src/engines/dynamic/windbg/bridge.py
@@ -45,7 +45,7 @@ from .output_parser import WinDbgOutputParser
 
 logger = logging.getLogger(__name__)
 
-# Conditional Pybag import — only available on Windows with Pybag installed
+# Conditional Pybag import -- only available on Windows with Pybag installed
 PYBAG_AVAILABLE = False
 pybag = None
 try:
@@ -68,7 +68,7 @@ _SDK_SEARCH_PATHS = [
 _CDB_TIMEOUT = 30
 
 # Timeout for KDNET kernel attach (seconds).  pybag's KernelDbg.attach() blocks
-# indefinitely waiting for the target — this caps the wait so callers get an
+# indefinitely waiting for the target -- this caps the wait so callers get an
 # actionable error instead of hanging forever.  Override with KDNET_TIMEOUT env.
 _KDNET_TIMEOUT = int(os.environ.get("KDNET_TIMEOUT", "60"))
 
@@ -118,7 +118,7 @@ _BLOCKED_COMMANDS = (
 )
 
 
-# --- Debug trace — activate with WINDBG_DEBUG=1 to log all bridge calls to file ---
+# --- Debug trace -- activate with WINDBG_DEBUG=1 to log all bridge calls to file ---
 def _setup_debug_log() -> logging.Logger:
     """Configure file logging when WINDBG_DEBUG env var is set."""
     debug_logger = logging.getLogger("windbg.trace")
@@ -332,7 +332,7 @@ class WinDbgBridge(Debugger):
         self._require_not_local("pause")
         self._require_not_dump("pause")
         try:
-            # Pybag has no break_in() — use the low-level DbgEng COM interface
+            # Pybag has no break_in() -- use the low-level DbgEng COM interface
             self._dbg._control.SetInterrupt(0)  # DEBUG_INTERRUPT_ACTIVE = 0
             self._state = DebuggerState.PAUSED
             return True
@@ -460,7 +460,7 @@ class WinDbgBridge(Debugger):
             kd = pybag.KernelDbg()
 
             def _attach_and_wait():
-                # attach() only opens the listening port — it returns before
+                # attach() only opens the listening port -- it returns before
                 # the target has connected.  wait() blocks until the target
                 # actually breaks in, giving us a live debug session.
                 kd.attach(conn_str)
@@ -468,7 +468,7 @@ class WinDbgBridge(Debugger):
 
             # Run attach+wait in a daemon thread so we can enforce a timeout.
             # IMPORTANT: Do NOT use the ThreadPoolExecutor as a context manager
-            # here — its __exit__ calls shutdown(wait=True) which blocks until
+            # here -- its __exit__ calls shutdown(wait=True) which blocks until
             # the thread finishes.  If kd.wait() hangs (target never breaks
             # in), that deadlocks the entire MCP tool call.  Instead, on
             # timeout we call shutdown(wait=False) to abandon the thread.
@@ -486,7 +486,7 @@ class WinDbgBridge(Debugger):
                     f"KDNET connection timed out after {timeout}s. "
                     f"The target did not break in on port {port}.\n\n"
                     "Troubleshooting:\n"
-                    "1. Reboot the TARGET machine AFTER starting this connect call — "
+                    "1. Reboot the TARGET machine AFTER starting this connect call -- "
                     "the host must be listening before the target sends its initial break.\n"
                     "2. Verify the key matches exactly (bcdedit /dbgsettings on the target).\n"
                     "3. Confirm the target's NIC supports KDNET "
@@ -518,7 +518,7 @@ class WinDbgBridge(Debugger):
         runs as Administrator.
 
         Registers and execution control (breakpoints, stepping, halting)
-        are NOT available in local mode — the debugger cannot break into
+        are NOT available in local mode -- the debugger cannot break into
         a kernel it is running on.  Those features require a remote
         KDNET connection to a separate target machine.
         """
@@ -533,7 +533,7 @@ class WinDbgBridge(Debugger):
             self._is_local_kernel = True
 
             # --- Soft validation: check if module listing works ---
-            # Only test module_list() — register reads (get_pc) always
+            # Only test module_list() -- register reads (get_pc) always
             # fail in local kernel mode because you cannot break into
             # the kernel when debugging locally.  That is a fundamental
             # Windows limitation, not a sign that bcdedit debug is off.
@@ -541,7 +541,7 @@ class WinDbgBridge(Debugger):
             try:
                 modules = self._dbg.module_list()
                 if not modules:
-                    # No modules returned — debug may not be enabled
+                    # No modules returned -- debug may not be enabled
                     self._local_kernel_limited = True
                     logger.warning(
                         "Local kernel connected but no modules returned. "
@@ -749,7 +749,7 @@ class WinDbgBridge(Debugger):
                 logger.info("Found CDB in SDK: %s", cdb)
                 return cdb
 
-        # 3. WinDbg Preview (Microsoft Store / winget) — WindowsApps location
+        # 3. WinDbg Preview (Microsoft Store / winget) -- WindowsApps location
         try:
             local_apps = Path(os.environ.get("LOCALAPPDATA", "")) / "Microsoft" / "WindowsApps"
             if local_apps.is_dir():
@@ -782,7 +782,7 @@ class WinDbgBridge(Debugger):
             logger.info("Found CDB on PATH: %s", cdb_on_path)
             return Path(cdb_on_path)
 
-        logger.warning("CDB not found — WinDbg commands will not be available")
+        logger.warning("CDB not found -- WinDbg commands will not be available")
         return None
 
     @staticmethod
@@ -813,7 +813,7 @@ class WinDbgBridge(Debugger):
             logger.info("Found KD on PATH: %s", kd_on_path)
             return Path(kd_on_path)
 
-        logger.info("KD not found — will fall back to CDB for kernel commands")
+        logger.info("KD not found -- will fall back to CDB for kernel commands")
         return None
 
     @_trace

--- a/src/engines/dynamic/x64dbg/bridge.py
+++ b/src/engines/dynamic/x64dbg/bridge.py
@@ -272,10 +272,10 @@ class X64DbgBridge(Debugger):
             try:
                 return self._request(endpoint, data)
             except AddressValidationError:
-                # Address validation failures are deterministic — never retry
+                # Address validation failures are deterministic -- never retry
                 raise
             except X64DbgAPIError:
-                # API errors are deterministic — never retry
+                # API errors are deterministic -- never retry
                 raise
             except (ConnectionError, RuntimeError) as e:
                 last_error = e
@@ -294,7 +294,7 @@ class X64DbgBridge(Debugger):
                         f"{error_msg}. Attempting reconnect "
                         f"({reconnect_count}/{self._max_reconnects})..."
                     )
-                    # Reset auth token — plugin may have restarted with a new token
+                    # Reset auth token -- plugin may have restarted with a new token
                     self._auth_token = None
                     self.connected = False
                     try:
@@ -1992,10 +1992,10 @@ class X64DbgBridge(Debugger):
             "message": result.get("message", "Instruction undone"),
         }
 
-    # Commands that must never reach DbgCmdExec — they load external code,
+    # Commands that must never reach DbgCmdExec -- they load external code,
     # write arbitrary files, or compromise the debugging session.
     # Trace configuration commands are also blocked here because their
-    # arguments (arbitrary commands, file paths) bypass validation — use
+    # arguments (arbitrary commands, file paths) bypass validation -- use
     # the dedicated set_trace_command / set_trace_log_file methods instead.
     _BLOCKED_COMMANDS = frozenset({
         "scriptdll", "scriptload", "scriptrun",
@@ -2108,7 +2108,7 @@ class X64DbgBridge(Debugger):
 
         Args:
             index: Zero-based watch index
-            mode: Trigger mode — one of: changed, disabled, unchanged,
+            mode: Trigger mode -- one of: changed, disabled, unchanged,
                   istrue, isfalse, isgreater, isless, isnotequal
 
         Returns:
@@ -5355,7 +5355,7 @@ class X64DbgBridge(Debugger):
         """
         Overlay a struct/type on a memory address for structured viewing.
 
-        This is the key type system command — it interprets raw memory
+        This is the key type system command -- it interprets raw memory
         at the given address as the specified struct/type.
 
         Args:
@@ -5683,7 +5683,7 @@ class X64DbgBridge(Debugger):
 
         Args:
             text: Log format string (e.g. "RIP={rip} RAX={rax}")
-            condition: Optional condition — only log when true
+            condition: Optional condition -- only log when true
 
         Returns:
             Command result dictionary
@@ -5707,7 +5707,7 @@ class X64DbgBridge(Debugger):
 
         Args:
             command: x64dbg command to run per step
-            condition: Optional condition — only run when true
+            condition: Optional condition -- only run when true
 
         Returns:
             Command result dictionary
@@ -5717,7 +5717,7 @@ class X64DbgBridge(Debugger):
         """
         if not command or not command.strip():
             raise ValueError("Trace command cannot be empty")
-        # Validate the INNER command against the blocklist — the trace engine
+        # Validate the INNER command against the blocklist -- the trace engine
         # will execute it directly, bypassing the normal command validation path.
         self._validate_command(command.strip())
         cmd = f"TraceSetCommand {command.strip()}"
@@ -5787,7 +5787,7 @@ class X64DbgBridge(Debugger):
         cmd = f"ticnd {condition.strip()}, {max_steps}"
         self.execute_command(cmd)
 
-        # Wait for trace to complete — use generous timeout
+        # Wait for trace to complete -- use generous timeout
         timeout_ms = max(60000, max_steps * 2)
         wait_result = self.wait_until_paused(timeout=timeout_ms)
 
@@ -5878,7 +5878,7 @@ class X64DbgBridge(Debugger):
         """
         Trace into beyond the last record (OEP finding).
 
-        Executes ``tibt`` — traces into calls, recording execution, and stops
+        Executes ``tibt`` -- traces into calls, recording execution, and stops
         when execution goes beyond any previously recorded address. Used
         primarily for finding the Original Entry Point (OEP) of packed binaries.
 
@@ -5912,7 +5912,7 @@ class X64DbgBridge(Debugger):
         """
         Trace over beyond the last record (OEP finding, skipping calls).
 
-        Executes ``tobt`` — traces over calls, recording execution, and stops
+        Executes ``tobt`` -- traces over calls, recording execution, and stops
         when execution goes beyond any previously recorded address.
 
         Args:

--- a/src/engines/dynamic/x64dbg/server/main.cpp
+++ b/src/engines/dynamic/x64dbg/server/main.cpp
@@ -31,7 +31,7 @@ static void InitLogging() {
     // If log file can't be opened, logging still works via stdout (if console exists)
 }
 
-// Simple logging — writes to log file and stdout
+// Simple logging -- writes to log file and stdout
 void Log(const char* format, ...) {
     char buffer[1024];
     va_list args;

--- a/src/engines/static/ghidra/project_cache.py
+++ b/src/engines/static/ghidra/project_cache.py
@@ -1,8 +1,18 @@
 """
 Project cache manager for Ghidra analysis results.
 Handles persistent storage and retrieval of analysis data.
+
+Caches are written as gzipped JSON (``.json.gz``). Legacy uncompressed
+``.json`` caches are transparently read for backward compatibility; when a
+legacy cache is loaded via :meth:`get_cached` it is *not* auto-migrated — the
+next :meth:`save_cached` call will produce a ``.json.gz`` file alongside it.
+
+Alongside each cache a small ``.funcidx.json`` side-car is maintained mapping
+function address → index into the ``functions`` list, enabling O(1) lookups
+without reading the full multi-megabyte cache.
 """
 
+import gzip
 import hashlib
 import json
 import logging
@@ -31,94 +41,120 @@ class ProjectCache:
         logger.info(f"Project cache initialized: {self.cache_dir}")
 
     def _get_binary_hash(self, binary_path: str) -> str:
-        """
-        Calculate SHA256 hash of binary file.
-
-        Args:
-            binary_path: Path to binary file
-
-        Returns:
-            Hex string of SHA256 hash
-        """
+        """Calculate SHA256 hash of binary file."""
         sha256 = hashlib.sha256()
         with open(binary_path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
                 sha256.update(chunk)
         return sha256.hexdigest()
 
-    def _get_cache_path(self, binary_hash: str) -> Path:
-        """Get cache file path for a binary hash."""
+    def _get_cache_path_gz(self, binary_hash: str) -> Path:
+        """Path for the gzipped cache (current format)."""
+        return self.cache_dir / f"{binary_hash}.json.gz"
+
+    def _get_cache_path_legacy(self, binary_hash: str) -> Path:
+        """Path for uncompressed cache (legacy format, read-only)."""
         return self.cache_dir / f"{binary_hash}.json"
 
+    def _resolve_cache_path(self, binary_hash: str) -> Path | None:
+        """Return the existing cache path (gz preferred, then legacy), or None."""
+        gz = self._get_cache_path_gz(binary_hash)
+        if gz.exists():
+            return gz
+        legacy = self._get_cache_path_legacy(binary_hash)
+        if legacy.exists():
+            return legacy
+        return None
+
     def _get_metadata_path(self, binary_hash: str) -> Path:
-        """Get metadata file path for a binary hash."""
         return self.cache_dir / f"{binary_hash}.meta.json"
 
+    def _get_funcidx_path(self, binary_hash: str) -> Path:
+        return self.cache_dir / f"{binary_hash}.funcidx.json"
+
     def has_cached(self, binary_path: str) -> bool:
-        """
-        Check if analysis results are cached for a binary.
-
-        Args:
-            binary_path: Path to binary file
-
-        Returns:
-            True if cache exists and is valid
-        """
+        """Check if analysis results are cached for a binary."""
         try:
             binary_hash = self._get_binary_hash(binary_path)
-            cache_path = self._get_cache_path(binary_hash)
-            return cache_path.exists()
+            return self._resolve_cache_path(binary_hash) is not None
         except Exception as e:
             logger.error(f"Error checking cache: {e}")
             return False
 
     def get_cached(self, binary_path: str) -> dict | None:
-        """
-        Retrieve cached analysis results.
-
-        Args:
-            binary_path: Path to binary file
-
-        Returns:
-            Analysis results dict, or None if not cached
-        """
+        """Retrieve cached analysis results (gz or legacy)."""
         try:
             binary_hash = self._get_binary_hash(binary_path)
-            cache_path = self._get_cache_path(binary_hash)
+            cache_path = self._resolve_cache_path(binary_hash)
 
-            if not cache_path.exists():
+            if cache_path is None:
                 logger.debug(f"No cache found for {binary_path}")
                 return None
 
-            with open(cache_path, encoding="utf-8") as f:
-                data = json.load(f)
+            if cache_path.suffix == ".gz":
+                with gzip.open(cache_path, "rt", encoding="utf-8") as f:
+                    data = json.load(f)
+            else:
+                with open(cache_path, encoding="utf-8") as f:
+                    data = json.load(f)
 
-            logger.info(f"Cache hit for {binary_path} (hash: {binary_hash[:8]}...)")
+            logger.info(
+                f"Cache hit for {binary_path} "
+                f"(hash: {binary_hash[:8]}..., fmt: {cache_path.suffix})"
+            )
             return data
 
         except Exception as e:
             logger.error(f"Error reading cache: {e}")
             return None
 
-    def save_cached(self, binary_path: str, data: dict) -> bool:
+    def get_cache_path(self, binary_path: str) -> Path | None:
         """
-        Save analysis results to cache.
+        Return the on-disk path for a binary's cache, or None if not cached.
 
-        Args:
-            binary_path: Path to binary file
-            data: Analysis results to cache
-
-        Returns:
-            True if saved successfully
+        Callers (e.g. resumable analysis) need the path to hand to Ghidra
+        without paying the cost of loading the JSON.
         """
         try:
             binary_hash = self._get_binary_hash(binary_path)
-            cache_path = self._get_cache_path(binary_hash)
-            metadata_path = self._get_metadata_path(binary_hash)
+            return self._resolve_cache_path(binary_hash)
+        except Exception as e:
+            logger.error(f"Error resolving cache path: {e}")
+            return None
 
-            # Save analysis data
-            with open(cache_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
+    def _build_function_index(self, data: dict) -> dict:
+        """Build {address: index} map from cached context's functions list."""
+        return {
+            func.get("address"): idx
+            for idx, func in enumerate(data.get("functions", []))
+            if func.get("address")
+        }
+
+    def save_cached(self, binary_path: str, data: dict) -> bool:
+        """Save analysis results to cache (gzipped) and write function index."""
+        try:
+            binary_hash = self._get_binary_hash(binary_path)
+            cache_path = self._get_cache_path_gz(binary_hash)
+            metadata_path = self._get_metadata_path(binary_hash)
+            funcidx_path = self._get_funcidx_path(binary_hash)
+            legacy_path = self._get_cache_path_legacy(binary_hash)
+
+            # Save gzipped analysis data
+            with gzip.open(cache_path, "wt", encoding="utf-8") as f:
+                json.dump(data, f)
+
+            # Drop legacy uncompressed cache if present (we now have a fresh .gz)
+            if legacy_path.exists():
+                try:
+                    legacy_path.unlink()
+                    logger.debug(f"Removed legacy uncompressed cache: {legacy_path}")
+                except OSError as e:
+                    logger.warning(f"Could not remove legacy cache: {e}")
+
+            # Build and persist function address index for O(1) lookups
+            func_index = self._build_function_index(data)
+            with open(funcidx_path, "w", encoding="utf-8") as f:
+                json.dump(func_index, f)
 
             # Save metadata
             metadata = {
@@ -126,38 +162,80 @@ class ProjectCache:
                 "binary_name": Path(binary_path).name,
                 "binary_hash": binary_hash,
                 "cached_at": time.time(),
-                "cache_version": "1.0",
+                "cache_version": "2.0",
+                "cache_format": "gzip",
+                "function_count": len(func_index),
             }
 
             with open(metadata_path, "w", encoding="utf-8") as f:
                 json.dump(metadata, f, indent=2)
 
-            logger.info(f"Saved cache for {binary_path} (hash: {binary_hash[:8]}...)")
+            logger.info(
+                f"Saved cache for {binary_path} "
+                f"(hash: {binary_hash[:8]}..., {len(func_index)} functions indexed)"
+            )
             return True
 
         except Exception as e:
             logger.error(f"Error saving cache: {e}")
             return False
 
-    def invalidate(self, binary_path: str) -> bool:
+    def get_function_by_address(
+        self, binary_path: str, address: str
+    ) -> dict | None:
         """
-        Invalidate cached results for a binary.
+        Fast lookup of a single function by address using the side-car index.
 
-        Args:
-            binary_path: Path to binary file
-
-        Returns:
-            True if invalidated successfully
+        Falls back to scanning the full cache if the index is missing (e.g. a
+        legacy cache that was never re-saved under the v2.0 format).
         """
         try:
             binary_hash = self._get_binary_hash(binary_path)
-            cache_path = self._get_cache_path(binary_hash)
-            metadata_path = self._get_metadata_path(binary_hash)
+            funcidx_path = self._get_funcidx_path(binary_hash)
 
-            if cache_path.exists():
-                cache_path.unlink()
-            if metadata_path.exists():
-                metadata_path.unlink()
+            if funcidx_path.exists():
+                with open(funcidx_path, encoding="utf-8") as f:
+                    index = json.load(f)
+                idx = index.get(address)
+                if idx is None:
+                    return None
+                # We still need the full cache to get the function body — but
+                # we now know it exists without scanning.
+                data = self.get_cached(binary_path)
+                if data is None:
+                    return None
+                functions = data.get("functions", [])
+                if 0 <= idx < len(functions):
+                    return functions[idx]
+                return None
+
+            # No index — legacy fallback: linear scan
+            data = self.get_cached(binary_path)
+            if data is None:
+                return None
+            for func in data.get("functions", []):
+                if func.get("address") == address:
+                    return func
+            return None
+
+        except Exception as e:
+            logger.error(f"Error looking up function by address: {e}")
+            return None
+
+    def invalidate(self, binary_path: str) -> bool:
+        """Invalidate cached results for a binary (all formats + sidecars)."""
+        try:
+            binary_hash = self._get_binary_hash(binary_path)
+            paths = [
+                self._get_cache_path_gz(binary_hash),
+                self._get_cache_path_legacy(binary_hash),
+                self._get_metadata_path(binary_hash),
+                self._get_funcidx_path(binary_hash),
+            ]
+
+            for p in paths:
+                if p.exists():
+                    p.unlink()
 
             logger.info(f"Invalidated cache for {binary_path}")
             return True
@@ -167,15 +245,7 @@ class ProjectCache:
             return False
 
     def get_metadata(self, binary_path: str) -> dict | None:
-        """
-        Get cache metadata for a binary.
-
-        Args:
-            binary_path: Path to binary file
-
-        Returns:
-            Metadata dict, or None if not cached
-        """
+        """Get cache metadata for a binary."""
         try:
             binary_hash = self._get_binary_hash(binary_path)
             metadata_path = self._get_metadata_path(binary_hash)
@@ -191,12 +261,7 @@ class ProjectCache:
             return None
 
     def list_cached(self) -> list[dict]:
-        """
-        List all cached binaries.
-
-        Returns:
-            List of metadata dicts for all cached binaries
-        """
+        """List all cached binaries."""
         cached_binaries = []
 
         for meta_file in self.cache_dir.glob("*.meta.json"):
@@ -210,37 +275,29 @@ class ProjectCache:
         return sorted(cached_binaries, key=lambda x: x.get("cached_at", 0), reverse=True)
 
     def clear_all(self) -> int:
-        """
-        Clear all cached data.
-
-        Returns:
-            Number of cache entries removed
-        """
+        """Clear all cached data (gz, legacy json, meta, funcidx)."""
         count = 0
 
-        for cache_file in self.cache_dir.glob("*.json"):
-            try:
-                cache_file.unlink()
-                count += 1
-            except Exception as e:
-                logger.error(f"Error deleting {cache_file}: {e}")
+        for pattern in ("*.json.gz", "*.json"):
+            for cache_file in self.cache_dir.glob(pattern):
+                try:
+                    cache_file.unlink()
+                    count += 1
+                except Exception as e:
+                    logger.error(f"Error deleting {cache_file}: {e}")
 
         logger.info(f"Cleared {count} cache entries")
         return count
 
     def get_cache_size(self) -> int:
-        """
-        Get total size of cache in bytes.
-
-        Returns:
-            Total cache size in bytes
-        """
+        """Get total size of cache in bytes (all cache + sidecar files)."""
         total_size = 0
 
-        for cache_file in self.cache_dir.glob("*.json"):
-            try:
-                total_size += cache_file.stat().st_size
-            except Exception as e:
-                logger.error(f"Error getting size of {cache_file}: {e}")
+        for pattern in ("*.json.gz", "*.json"):
+            for cache_file in self.cache_dir.glob(pattern):
+                try:
+                    total_size += cache_file.stat().st_size
+                except Exception as e:
+                    logger.error(f"Error getting size of {cache_file}: {e}")
 
         return total_size

--- a/src/engines/static/ghidra/project_cache.py
+++ b/src/engines/static/ghidra/project_cache.py
@@ -4,7 +4,7 @@ Handles persistent storage and retrieval of analysis data.
 
 Caches are written as gzipped JSON (``.json.gz``). Legacy uncompressed
 ``.json`` caches are transparently read for backward compatibility; when a
-legacy cache is loaded via :meth:`get_cached` it is *not* auto-migrated — the
+legacy cache is loaded via :meth:`get_cached` it is *not* auto-migrated -- the
 next :meth:`save_cached` call will produce a ``.json.gz`` file alongside it.
 
 Alongside each cache a small ``.funcidx.json`` side-car is maintained mapping
@@ -199,7 +199,7 @@ class ProjectCache:
                 idx = index.get(address)
                 if idx is None:
                     return None
-                # We still need the full cache to get the function body — but
+                # We still need the full cache to get the function body -- but
                 # we now know it exists without scanning.
                 data = self.get_cached(binary_path)
                 if data is None:
@@ -209,7 +209,7 @@ class ProjectCache:
                     return functions[idx]
                 return None
 
-            # No index — legacy fallback: linear scan
+            # No index -- legacy fallback: linear scan
             data = self.get_cached(binary_path)
             if data is None:
                 return None

--- a/src/engines/static/ghidra/runner.py
+++ b/src/engines/static/ghidra/runner.py
@@ -156,6 +156,54 @@ class GhidraRunner:
 
         return path
 
+    def _stage_pdb(self, binary_path: Path | str, pdb_path: str) -> Path:
+        """
+        Stage a PDB file next to the binary so Ghidra's PdbUniversalAnalyzer
+        auto-locates it. Symlinks on Unix, copies on Windows (where symlinks
+        need admin privileges).
+
+        Returns the staged path. Callers should pass it to ``_cleanup_pdb``
+        once Ghidra has finished reading the binary.
+        """
+        import shutil
+
+        src = Path(pdb_path)
+        if not src.exists():
+            raise FileNotFoundError(f"PDB not found: {pdb_path}")
+
+        binary = Path(binary_path)
+        # Ghidra looks for <binary-with-suffix>.pdb adjacent to the binary
+        # (e.g. foo.exe → foo.pdb). Use stem to normalise.
+        dest = binary.parent / f"{binary.stem}.pdb"
+
+        if dest.exists() and dest.resolve() == src.resolve():
+            # Already in the right place
+            return dest
+
+        # Remove any prior artefact so staging is idempotent
+        if dest.exists() or dest.is_symlink():
+            dest.unlink()
+
+        if self.system == "Windows":
+            shutil.copy2(src, dest)
+        else:
+            try:
+                dest.symlink_to(src.resolve())
+            except OSError:
+                # Fallback to copy if symlink isn't allowed
+                shutil.copy2(src, dest)
+        return dest
+
+    def _cleanup_pdb(self, staged_pdb: Path | None) -> None:
+        """Best-effort removal of a PDB staged by ``_stage_pdb``."""
+        if staged_pdb is None:
+            return
+        try:
+            if staged_pdb.exists() or staged_pdb.is_symlink():
+                staged_pdb.unlink()
+        except OSError as e:
+            logger.warning(f"Failed to remove staged PDB {staged_pdb}: {e}")
+
     def _cleanup_project(self, project_dir: Path, project_name: str) -> None:
         """
         Clean up a Ghidra project directory and lock files.
@@ -204,6 +252,8 @@ class GhidraRunner:
         resume_from_cache: str | None = None,
         start_address: str | None = None,
         end_address: str | None = None,
+        pdb_path: str | None = None,
+        enable_fid: bool = False,
     ) -> dict:
         """
         Run Ghidra headless analysis on a binary.
@@ -225,6 +275,10 @@ class GhidraRunner:
                 already present are skipped and their results preserved
             start_address: Hex start address (e.g. "0x61abbc") — skip functions below
             end_address: Hex end address — skip functions above
+            pdb_path: Optional path to a PDB file. Staged next to the binary so
+                Ghidra's PdbUniversalAnalyzer picks it up automatically.
+            enable_fid: When True, set GHIDRA_ENABLE_FID=1 so the Jython script
+                runs Function ID library matching per function.
 
         Returns:
             dict with analysis results and metadata
@@ -274,8 +328,18 @@ class GhidraRunner:
             env["GHIDRA_START_ADDRESS"] = str(start_address)
         if end_address:
             env["GHIDRA_END_ADDRESS"] = str(end_address)
+        if enable_fid:
+            env["GHIDRA_ENABLE_FID"] = "1"
         # Give script a wall-clock budget with margin for JSON serialization
         env["GHIDRA_ANALYSIS_BUDGET"] = str(max(timeout - 60, 60))
+
+        # Stage PDB next to the binary so Ghidra's PdbUniversalAnalyzer finds
+        # it. Auto-cleanup on success/failure so we don't leave dangling
+        # artefacts.
+        staged_pdb = None
+        if pdb_path:
+            staged_pdb = self._stage_pdb(binary_path, pdb_path)
+            logger.info(f"Staged PDB at {staged_pdb}")
 
         logger.debug(
             f"Analysis settings: function_timeout={function_timeout}, "
@@ -385,6 +449,12 @@ class GhidraRunner:
                 f"Ghidra analysis failed with exit code {e.returncode}. "
                 f"stdout (last 2000 chars): {stdout_tail}"
             ) from e
+
+        finally:
+            # Always remove the PDB we staged — Ghidra has either read it by
+            # now or failed outright. Leaving it behind would confuse future
+            # analyses with a mismatched PDB.
+            self._cleanup_pdb(staged_pdb)
 
     def diagnose(self) -> dict:
         """

--- a/src/engines/static/ghidra/runner.py
+++ b/src/engines/static/ghidra/runner.py
@@ -271,10 +271,10 @@ class GhidraRunner:
             function_timeout: Per-function decompilation timeout (default: 30s)
             max_functions: Maximum functions to analyze (default: unlimited)
             skip_decompile: Skip decompilation for faster analysis (default: False)
-            resume_from_cache: Path to a previous cache JSON (plain or .gz) — functions
+            resume_from_cache: Path to a previous cache JSON (plain or .gz) -- functions
                 already present are skipped and their results preserved
-            start_address: Hex start address (e.g. "0x61abbc") — skip functions below
-            end_address: Hex end address — skip functions above
+            start_address: Hex start address (e.g. "0x61abbc") -- skip functions below
+            end_address: Hex end address -- skip functions above
             pdb_path: Optional path to a PDB file. Staged next to the binary so
                 Ghidra's PdbUniversalAnalyzer picks it up automatically.
             enable_fid: When True, set GHIDRA_ENABLE_FID=1 so the Jython script
@@ -451,7 +451,7 @@ class GhidraRunner:
             ) from e
 
         finally:
-            # Always remove the PDB we staged — Ghidra has either read it by
+            # Always remove the PDB we staged -- Ghidra has either read it by
             # now or failed outright. Leaving it behind would confuse future
             # analyses with a mismatched PDB.
             self._cleanup_pdb(staged_pdb)

--- a/src/engines/static/ghidra/runner.py
+++ b/src/engines/static/ghidra/runner.py
@@ -201,6 +201,9 @@ class GhidraRunner:
         function_timeout: int | None = None,
         max_functions: int | None = None,
         skip_decompile: bool = False,
+        resume_from_cache: str | None = None,
+        start_address: str | None = None,
+        end_address: str | None = None,
     ) -> dict:
         """
         Run Ghidra headless analysis on a binary.
@@ -218,6 +221,10 @@ class GhidraRunner:
             function_timeout: Per-function decompilation timeout (default: 30s)
             max_functions: Maximum functions to analyze (default: unlimited)
             skip_decompile: Skip decompilation for faster analysis (default: False)
+            resume_from_cache: Path to a previous cache JSON (plain or .gz) — functions
+                already present are skipped and their results preserved
+            start_address: Hex start address (e.g. "0x61abbc") — skip functions below
+            end_address: Hex end address — skip functions above
 
         Returns:
             dict with analysis results and metadata
@@ -261,11 +268,21 @@ class GhidraRunner:
             env["GHIDRA_MAX_FUNCTIONS"] = str(max_functions)
         if skip_decompile:
             env["GHIDRA_SKIP_DECOMPILE"] = "1"
+        if resume_from_cache:
+            env["GHIDRA_RESUME_CACHE"] = str(resume_from_cache)
+        if start_address:
+            env["GHIDRA_START_ADDRESS"] = str(start_address)
+        if end_address:
+            env["GHIDRA_END_ADDRESS"] = str(end_address)
         # Give script a wall-clock budget with margin for JSON serialization
         env["GHIDRA_ANALYSIS_BUDGET"] = str(max(timeout - 60, 60))
 
-        logger.debug(f"Analysis settings: function_timeout={function_timeout}, "
-                     f"max_functions={max_functions}, skip_decompile={skip_decompile}")
+        logger.debug(
+            f"Analysis settings: function_timeout={function_timeout}, "
+            f"max_functions={max_functions}, skip_decompile={skip_decompile}, "
+            f"resume_from_cache={resume_from_cache}, "
+            f"start_address={start_address}, end_address={end_address}"
+        )
 
         # Build command - processor/loader must come immediately after binary path
         cmd = [

--- a/src/engines/static/ghidra/scripts/core_analysis.py
+++ b/src/engines/static/ghidra/scripts/core_analysis.py
@@ -350,11 +350,27 @@ def extract_comprehensive_analysis():
 
     # Extract metadata
     print("[*] Extracting metadata...")
+    # `language` must be the canonical colon-delimited Ghidra LanguageID
+    # (e.g. "x86:LE:64:default") so downstream tools like analyze_control_flow
+    # can parse architecture/bitness. The Language object's toString() is a
+    # human-readable description, which is NOT parseable -- capture it
+    # separately for display.
+    try:
+        language_id = safe_unicode(program.getLanguageID().getIdAsString())
+    except Exception:
+        # Fall back to whatever the Language object stringifies to
+        language_id = safe_unicode(program.getLanguage())
+    try:
+        language_desc = safe_unicode(program.getLanguage())
+    except Exception:
+        language_desc = language_id
+
     context["metadata"] = {
         "name": safe_unicode(program.getName()),
         "executable_path": safe_unicode(program.getExecutablePath()),
         "executable_format": safe_unicode(program.getExecutableFormat()),
-        "language": safe_unicode(program.getLanguage()),
+        "language": language_id,
+        "language_description": language_desc,
         "compiler": safe_unicode(program.getCompilerSpec()),
         "image_base": safe_unicode(program.getImageBase()),
         "min_address": safe_unicode(program.getMinAddress()),

--- a/src/engines/static/ghidra/scripts/core_analysis.py
+++ b/src/engines/static/ghidra/scripts/core_analysis.py
@@ -6,6 +6,7 @@
 # Note: currentProgram and other Ghidra globals are provided at runtime
 
 import codecs
+import gzip
 import json
 import os
 import time
@@ -167,6 +168,54 @@ def decompile_with_timeout(decompiler, function, timeout_seconds, monitor, execu
         return (None, "error", safe_unicode(e))
 
 
+def _parse_hex_addr(raw):
+    """Parse an address string ('0x1800', '1800') to int, or None."""
+    if not raw:
+        return None
+    try:
+        raw = raw.strip()
+        if raw.lower().startswith("0x"):
+            return int(raw, 16)
+        return int(raw, 16)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _load_resume_cache(path):
+    """
+    Load a previous analysis cache for resumable analysis.
+
+    Supports both gzipped (.json.gz) and plain (.json) cache files.
+    Returns (context_dict, set_of_analyzed_addresses) or (None, set()).
+    """
+    if not path or not os.path.exists(path):
+        return None, set()
+
+    try:
+        if path.endswith(".gz"):
+            f = gzip.open(path, "rb")
+            try:
+                data = json.loads(f.read().decode("utf-8"))
+            finally:
+                f.close()
+        else:
+            f = codecs.open(path, "r", encoding="utf-8")
+            try:
+                data = json.load(f)
+            finally:
+                f.close()
+
+        analyzed = set()
+        for func in data.get("functions", []):
+            addr = func.get("address")
+            if addr:
+                analyzed.add(addr)
+        return data, analyzed
+    except Exception as e:
+        print(safe_format("[!] Failed to load resume cache {}: {}", path, safe_unicode(e)))
+        return None, set()
+
+
 def extract_comprehensive_analysis():
     """Extract comprehensive analysis data from the current program."""
 
@@ -183,16 +232,33 @@ def extract_comprehensive_analysis():
     # GHIDRA_FUNCTION_TIMEOUT: Per-function decompilation timeout in seconds (default: 30)
     # GHIDRA_MAX_FUNCTIONS: Maximum number of functions to analyze (default: unlimited)
     # GHIDRA_SKIP_DECOMPILE: Skip decompilation entirely (faster, but no pseudocode)
+    # GHIDRA_RESUME_CACHE: Path to previous cache JSON; functions already in it are skipped
+    # GHIDRA_START_ADDRESS / GHIDRA_END_ADDRESS: Hex address bounds for chunked analysis
     function_timeout = int(os.environ.get("GHIDRA_FUNCTION_TIMEOUT", "30"))
     max_functions = int(os.environ.get("GHIDRA_MAX_FUNCTIONS", "0"))  # 0 = unlimited
     skip_decompile = os.environ.get("GHIDRA_SKIP_DECOMPILE", "").lower() in ("1", "true", "yes")
     total_budget = int(os.environ.get("GHIDRA_ANALYSIS_BUDGET", "540"))
+    resume_cache_path = os.environ.get("GHIDRA_RESUME_CACHE", "") or None
+    start_addr = _parse_hex_addr(os.environ.get("GHIDRA_START_ADDRESS"))
+    end_addr = _parse_hex_addr(os.environ.get("GHIDRA_END_ADDRESS"))
 
     print(safe_format("[*] Analysis settings:"))
     print(safe_format("    Function timeout: {}s", function_timeout))
     print(safe_format("    Max functions: {}", max_functions if max_functions > 0 else "unlimited"))
     print(safe_format("    Skip decompile: {}", skip_decompile))
     print(safe_format("    Wall-clock budget: {}s", total_budget))
+    if resume_cache_path:
+        print(safe_format("    Resume cache: {}", resume_cache_path))
+    if start_addr is not None:
+        print(safe_format("    Start address: 0x{:x}", start_addr))
+    if end_addr is not None:
+        print(safe_format("    End address: 0x{:x}", end_addr))
+
+    # Load prior cache if resuming
+    resume_context, already_analyzed = _load_resume_cache(resume_cache_path)
+    if resume_context:
+        print(safe_format("[*] Resumed from cache: {} functions already analyzed",
+                          len(already_analyzed)))
 
     # Initialize decompiler
     decompiler = DecompInterface()
@@ -202,31 +268,58 @@ def extract_comprehensive_analysis():
     # Tasks are submitted one at a time, so a single thread is sufficient
     decompile_executor = Executors.newSingleThreadExecutor()
 
-    context = {
-        "metadata": {},
-        "functions": [],
-        "imports": [],
-        "exports": [],
-        "strings": [],
-        "memory_map": [],
-        "xrefs": {},
-        "data_types": {
-            "structures": [],
-            "enums": []
-        },
-        "analysis_stats": {
+    if resume_context:
+        # Start from the previous cache — re-extract metadata/memory/imports/strings
+        # below, but preserve previously-decompiled functions.
+        context = resume_context
+        # Reset collections we re-extract every run
+        context["imports"] = []
+        context["exports"] = []
+        context["strings"] = []
+        context["memory_map"] = []
+        context.setdefault("functions", [])
+        context.setdefault("xrefs", {})
+        context.setdefault("data_types", {"structures": [], "enums": []})
+        context.setdefault("skipped_functions", [])
+        context["analysis_stats"] = {
             "functions_analyzed": 0,
             "functions_skipped": 0,
             "decompile_failures": 0,
             "decompile_timeouts": 0,
-            "thread_timeouts": 0,  # Hard thread timeouts (anti-analysis code)
-            "internal_timeouts": 0,  # Ghidra's internal decompiler timeouts
+            "thread_timeouts": 0,
+            "internal_timeouts": 0,
             "partial_results": False,
             "function_timeout_setting": function_timeout,
-            "max_functions_setting": max_functions if max_functions > 0 else None
-        },
-        "skipped_functions": []  # Track functions that couldn't be analyzed
-    }
+            "max_functions_setting": max_functions if max_functions > 0 else None,
+            "resumed": True,
+            "resumed_from_count": len(already_analyzed),
+        }
+    else:
+        context = {
+            "metadata": {},
+            "functions": [],
+            "imports": [],
+            "exports": [],
+            "strings": [],
+            "memory_map": [],
+            "xrefs": {},
+            "data_types": {
+                "structures": [],
+                "enums": []
+            },
+            "analysis_stats": {
+                "functions_analyzed": 0,
+                "functions_skipped": 0,
+                "decompile_failures": 0,
+                "decompile_timeouts": 0,
+                "thread_timeouts": 0,  # Hard thread timeouts (anti-analysis code)
+                "internal_timeouts": 0,  # Ghidra's internal decompiler timeouts
+                "partial_results": False,
+                "function_timeout_setting": function_timeout,
+                "max_functions_setting": max_functions if max_functions > 0 else None
+            },
+            "skipped_functions": []  # Track functions that couldn't be analyzed
+        }
 
     # Extract metadata
     print("[*] Extracting metadata...")
@@ -336,11 +429,37 @@ def extract_comprehensive_analysis():
 
     analysis_start = time.time()
 
+    skipped_by_resume = 0
+    skipped_by_range = 0
+
     while function_iterator.hasNext():
         function = function_iterator.next()
+
+        entry_point = function.getEntryPoint()
+        entry_str = safe_unicode(entry_point)
+
+        # Skip functions already present in resume cache
+        if already_analyzed and entry_str in already_analyzed:
+            skipped_by_resume += 1
+            continue
+
+        # Apply address-range filter (chunked analysis)
+        if start_addr is not None or end_addr is not None:
+            try:
+                ep_int = int(entry_point.getOffset())
+            except Exception:
+                ep_int = None
+            if ep_int is not None:
+                if start_addr is not None and ep_int < start_addr:
+                    skipped_by_range += 1
+                    continue
+                if end_addr is not None and ep_int > end_addr:
+                    skipped_by_range += 1
+                    continue
+
         function_count += 1
 
-        # Check max functions limit
+        # Check max functions limit (counts functions analyzed this run only)
         if max_functions > 0 and function_count > max_functions:
             print(safe_format("[!] Reached max function limit ({}), stopping analysis", max_functions))
             context["analysis_stats"]["partial_results"] = True
@@ -352,7 +471,6 @@ def extract_comprehensive_analysis():
 
         # Get function signature
         signature = function.getSignature()
-        entry_point = function.getEntryPoint()
         body = function.getBody()
 
         # Get basic info
@@ -507,6 +625,9 @@ def extract_comprehensive_analysis():
     context["analysis_stats"]["internal_timeouts"] = internal_timeout_count
     context["analysis_stats"]["decompile_failures"] = decompile_failure_count
     context["analysis_stats"]["functions_skipped"] = len(context["skipped_functions"])
+    context["analysis_stats"]["skipped_by_resume"] = skipped_by_resume
+    context["analysis_stats"]["skipped_by_range"] = skipped_by_range
+    context["analysis_stats"]["total_functions_in_cache"] = len(context["functions"])
 
     # Extract data types (structures)
     print("[*] Extracting data types...")

--- a/src/engines/static/ghidra/scripts/core_analysis.py
+++ b/src/engines/static/ghidra/scripts/core_analysis.py
@@ -241,6 +241,7 @@ def extract_comprehensive_analysis():
     resume_cache_path = os.environ.get("GHIDRA_RESUME_CACHE", "") or None
     start_addr = _parse_hex_addr(os.environ.get("GHIDRA_START_ADDRESS"))
     end_addr = _parse_hex_addr(os.environ.get("GHIDRA_END_ADDRESS"))
+    enable_fid = os.environ.get("GHIDRA_ENABLE_FID", "").lower() in ("1", "true", "yes")
 
     print(safe_format("[*] Analysis settings:"))
     print(safe_format("    Function timeout: {}s", function_timeout))
@@ -253,6 +254,32 @@ def extract_comprehensive_analysis():
         print(safe_format("    Start address: 0x{:x}", start_addr))
     if end_addr is not None:
         print(safe_format("    End address: 0x{:x}", end_addr))
+    if enable_fid:
+        print(safe_format("    FID matching: enabled"))
+
+    # Lazy-initialise Ghidra's Function ID service. Wrapped because the FID
+    # APIs vary slightly across Ghidra versions — failure here degrades to
+    # "no FID matches", never a hard error.
+    fid_service = None
+    fid_files = None
+    if enable_fid:
+        try:
+            from ghidra.feature.fid.db import FidFileManager
+            from ghidra.feature.fid.service import FidService
+            fid_service = FidService()
+            fm = FidFileManager.getInstance()
+            if fm is not None:
+                fid_files = fm.getFidFiles()
+            if fid_service.canProcess(program.getLanguage()) and fid_files:
+                print(safe_format("    FID databases available: {}", len(fid_files)))
+            else:
+                print("    [!] FID enabled but no FID databases / unsupported language; disabling.")
+                fid_service = None
+                fid_files = None
+        except Exception as fid_err:
+            print(safe_format("    [!] FID init failed ({}); continuing without FID", safe_unicode(fid_err)))
+            fid_service = None
+            fid_files = None
 
     # Load prior cache if resuming
     resume_context, already_analyzed = _load_resume_cache(resume_cache_path)
@@ -473,6 +500,16 @@ def extract_comprehensive_analysis():
         signature = function.getSignature()
         body = function.getBody()
 
+        # Capture how the function name was assigned (USER_DEFINED / IMPORTED /
+        # ANALYSIS / DEFAULT). Analyzer-assigned non-default names are the
+        # signal that FID / demangler / stdlib-heuristic identified this as a
+        # known routine.
+        try:
+            sym = function.getSymbol()
+            name_source = safe_unicode(sym.getSource()) if sym else u"UNKNOWN"
+        except Exception:
+            name_source = u"UNKNOWN"
+
         # Get basic info
         function_info = {
             "name": safe_unicode(function.getName()),
@@ -481,11 +518,14 @@ def extract_comprehensive_analysis():
             "signature": safe_unicode(signature),
             "is_thunk": function.isThunk(),
             "is_external": function.isExternal(),
+            "name_source": name_source,
             "parameters": [],
             "local_variables": [],
             "called_functions": [],
             "pseudocode": None,
             "basic_blocks": [],
+            "jump_tables": [],
+            "fid_match": None,
             "decompile_status": "not_attempted"  # Track decompilation status
         }
 
@@ -533,6 +573,74 @@ def extract_comprehensive_analysis():
         except Exception as e:
             print(safe_format("    Warning: Could not extract basic blocks for {}: {}",
                               safe_unicode(function.getName()), safe_unicode(e)))
+
+        # Extract jump / switch tables — instructions whose flow type is a
+        # computed jump expose their resolved targets via getFlows(). Works
+        # without HighFunction/P-Code so it stays cheap and always available.
+        try:
+            if body:
+                instr_iter = listing.getInstructions(body, True)
+                while instr_iter.hasNext():
+                    inst = instr_iter.next()
+                    ft = inst.getFlowType()
+                    if ft is not None and ft.isComputed() and ft.isJump():
+                        try:
+                            targets = inst.getFlows()
+                        except Exception:
+                            targets = None
+                        if not targets:
+                            continue
+                        function_info["jump_tables"].append({
+                            "source_addr": safe_unicode(inst.getAddress()),
+                            "targets": [safe_unicode(t) for t in targets],
+                        })
+        except Exception as e:
+            print(safe_format("    Warning: Could not extract jump tables for {}: {}",
+                              safe_unicode(function.getName()), safe_unicode(e)))
+
+        # Optional: Function ID (FID) library match.
+        # Iterates installed FID databases and picks the highest-scoring
+        # match. Defensive: any API mismatch / version drift falls through
+        # to "no match" without interrupting analysis.
+        if fid_service is not None and fid_files:
+            try:
+                best = None
+                for fid_file in fid_files:
+                    try:
+                        matches = fid_service.processFunction(function, fid_file, monitor)
+                    except AttributeError:
+                        # Older Ghidra API — different signature, skip silently
+                        matches = None
+                    except Exception:
+                        matches = None
+                    if not matches:
+                        continue
+                    for m in matches:
+                        try:
+                            score = float(m.getOverallScore())
+                        except Exception:
+                            score = 0.0
+                        if best is None or score > best[0]:
+                            best = (score, m, fid_file)
+                if best is not None:
+                    _, m, fid_file = best
+                    try:
+                        name_match = safe_unicode(m.getNameMatch())
+                    except Exception:
+                        name_match = u""
+                    try:
+                        library = safe_unicode(fid_file.getName())
+                    except Exception:
+                        library = u""
+                    function_info["fid_match"] = {
+                        "name": name_match,
+                        "library": library,
+                        "confidence": best[0],
+                    }
+            except Exception as e:
+                # Never let FID failures break per-function extraction
+                print(safe_format("    Warning: FID match failed for {}: {}",
+                                  safe_unicode(function.getName()), safe_unicode(e)))
 
         # Decompile function (for non-thunk, non-external functions)
         if skip_decompile:

--- a/src/engines/static/ghidra/scripts/core_analysis.py
+++ b/src/engines/static/ghidra/scripts/core_analysis.py
@@ -258,7 +258,7 @@ def extract_comprehensive_analysis():
         print(safe_format("    FID matching: enabled"))
 
     # Lazy-initialise Ghidra's Function ID service. Wrapped because the FID
-    # APIs vary slightly across Ghidra versions — failure here degrades to
+    # APIs vary slightly across Ghidra versions -- failure here degrades to
     # "no FID matches", never a hard error.
     fid_service = None
     fid_files = None
@@ -296,7 +296,7 @@ def extract_comprehensive_analysis():
     decompile_executor = Executors.newSingleThreadExecutor()
 
     if resume_context:
-        # Start from the previous cache — re-extract metadata/memory/imports/strings
+        # Start from the previous cache -- re-extract metadata/memory/imports/strings
         # below, but preserve previously-decompiled functions.
         context = resume_context
         # Reset collections we re-extract every run
@@ -574,7 +574,7 @@ def extract_comprehensive_analysis():
             print(safe_format("    Warning: Could not extract basic blocks for {}: {}",
                               safe_unicode(function.getName()), safe_unicode(e)))
 
-        # Extract jump / switch tables — instructions whose flow type is a
+        # Extract jump / switch tables -- instructions whose flow type is a
         # computed jump expose their resolved targets via getFlows(). Works
         # without HighFunction/P-Code so it stays cheap and always available.
         try:
@@ -609,7 +609,7 @@ def extract_comprehensive_analysis():
                     try:
                         matches = fid_service.processFunction(function, fid_file, monitor)
                     except AttributeError:
-                        # Older Ghidra API — different signature, skip silently
+                        # Older Ghidra API -- different signature, skip silently
                         matches = None
                     except Exception:
                         matches = None

--- a/src/server.py
+++ b/src/server.py
@@ -364,7 +364,7 @@ def get_analysis_context(
             logger.info(f"Resuming analysis from cache: {resume_from_cache}")
 
     try:
-        # Default bumped to 1800s (30 min) — large binaries routinely need more
+        # Default bumped to 1800s (30 min) -- large binaries routinely need more
         # than the old 10-minute ceiling. Bounds are still 30s..3600s.
         timeout = get_config_int("GHIDRA_TIMEOUT", 1800)
         timeout = validate_numeric_range(timeout, 30, 3600, "GHIDRA_TIMEOUT")
@@ -523,7 +523,7 @@ def analyze_binary(
         loader: Optional loader name when AutoImporter fails (e.g., "PeLoader" for Windows PE)
         skip_compatibility_check: Skip pre-analysis compatibility check (default: False)
         skip_decompile: Skip decompilation for a fast structural pass (no pseudocode).
-            Recommended for a first pass on very large binaries — functions,
+            Recommended for a first pass on very large binaries -- functions,
             imports, strings, and memory map are still extracted.
         max_functions: Cap how many functions to process this run (pairs with
             ``incremental`` for multi-pass coverage of huge binaries).
@@ -551,7 +551,7 @@ def analyze_binary(
         Common Ghidra loaders: PeLoader, ElfLoader, MachoLoader, BinaryLoader, CoffLoader
 
         Large-binary workflow (e.g. 17MB+ with 60K+ functions):
-        1. First pass: ``analyze_binary(..., skip_decompile=True)`` — structure only.
+        1. First pass: ``analyze_binary(..., skip_decompile=True)`` -- structure only.
         2. Extend: ``analyze_binary(..., incremental=True, max_functions=5000)``
            repeatedly, or target a range with ``start_address``/``end_address``.
     """
@@ -661,7 +661,7 @@ Format: {compat_info.format.value}
                 summary += f"- Skipped (outside address range): {stats['skipped_by_range']}\n"
             if stats.get("partial_results"):
                 summary += (
-                    "- ⚠️  Partial results — hit max_functions or wall-clock budget. "
+                    "- ⚠️  Partial results -- hit max_functions or wall-clock budget. "
                     "Re-run with `incremental=True` to extend coverage.\n"
                 )
 

--- a/src/server.py
+++ b/src/server.py
@@ -27,10 +27,12 @@ from src.engines.static.ghidra.runner import GhidraRunner
 from src.tools.control_flow_tools import register_control_flow_tools
 from src.tools.dotnet_tools import register_dotnet_tools
 from src.tools.dynamic_tools import register_dynamic_tools
+from src.tools.fid_tools import register_fid_tools
 from src.tools.function_hash_tools import register_function_hash_tools
 from src.tools.malware_tools import register_malware_tools
 from src.tools.pe_tools import register_pe_tools
 from src.tools.reporting import register_reporting_tools
+from src.tools.review_tools import register_review_tools
 from src.tools.triage_tools import register_triage_tools
 from src.tools.vt_tools import register_vt_tools
 from src.tools.windbg_tools import register_windbg_tools
@@ -284,6 +286,8 @@ def get_analysis_context(
     incremental: bool = False,
     start_address: str | None = None,
     end_address: str | None = None,
+    pdb_path: str | None = None,
+    enable_fid: bool = False,
 ) -> dict:
     """
     Get or create analysis context for a binary.
@@ -304,6 +308,9 @@ def get_analysis_context(
             functions and extends coverage rather than restarting.
         start_address / end_address: Hex bounds used to restrict the run to a
             sub-range (``"0x61abbc"``). Pairs well with ``incremental``.
+        pdb_path: Path to a PDB file. Staged next to the binary so Ghidra's
+            PdbUniversalAnalyzer picks it up. Forces a fresh analysis if set.
+        enable_fid: Run Ghidra's Function ID library matching per function.
 
     Returns:
         Analysis context dict
@@ -330,9 +337,10 @@ def get_analysis_context(
 
     # Short-circuit to cache unless the caller asked to re-analyze,
     # is overriding the processor/loader, or is extending coverage via
-    # incremental/range options.
+    # incremental/range options. PDB/FID both require a fresh Ghidra run.
     extending = incremental or start_address or end_address
-    if not force_reanalyze and not processor and not loader and not extending:
+    if not force_reanalyze and not processor and not loader and not extending \
+            and not pdb_path and not enable_fid:
         cached_context = cache.get_cached(binary_path)
         if cached_context:
             logger.info(f"Using cached analysis for {binary_path}")
@@ -375,6 +383,8 @@ def get_analysis_context(
             resume_from_cache=str(resume_from_cache) if resume_from_cache else None,
             start_address=start_address,
             end_address=end_address,
+            pdb_path=pdb_path,
+            enable_fid=enable_fid,
         )
 
         # Save Ghidra output to debug file for inspection
@@ -493,6 +503,8 @@ def analyze_binary(
     incremental: bool = False,
     start_address: str | None = None,
     end_address: str | None = None,
+    pdb_path: str | None = None,
+    enable_fid: bool = False,
 ) -> str:
     """
     Analyze a binary file with Ghidra headless analyzer.
@@ -521,6 +533,11 @@ def analyze_binary(
             fresh. Previously-analyzed functions are skipped and preserved.
         start_address / end_address: Hex bounds to restrict the run to an
             address range (e.g. ``"0x61abbc"``).
+        pdb_path: Path to a Windows PDB file. Staged next to the binary so
+            Ghidra's PdbUniversalAnalyzer can apply symbolic function names.
+        enable_fid: Run Ghidra's Function ID library fingerprinting; matches
+            are stored per-function in ``fid_match``. Query via ``fid_match``
+            tool after analysis.
 
     Returns:
         Analysis summary with basic statistics, or compatibility warning if issues detected
@@ -577,6 +594,8 @@ Format: {compat_info.format.value}
             incremental=incremental,
             start_address=start_address,
             end_address=end_address,
+            pdb_path=pdb_path,
+            enable_fid=enable_fid,
         )
 
         metadata = context.get("metadata", {})
@@ -662,6 +681,71 @@ Use other tools like get_functions, get_imports, decompile_function to explore t
         # Unexpected error - log internally, return safe message
         logger.exception(f"analyze_binary failed: {e}")
         return safe_error_message("Analysis failed unexpectedly", e)
+
+
+@app.tool()
+@log_to_session
+def load_pdb(binary_path: str, pdb_path: str) -> str:
+    """
+    Apply a Windows PDB to an analyzed binary.
+
+    Stages the PDB next to the binary (Ghidra's PdbUniversalAnalyzer
+    expects ``<binary-stem>.pdb`` adjacency), invalidates any existing
+    cache, and re-runs analysis so symbolic function names propagate.
+
+    Args:
+        binary_path: Path to the binary
+        pdb_path: Path to the PDB file
+
+    Returns:
+        Summary comparing pre/post symbolic-function counts.
+    """
+    try:
+        # Capture pre-state for before/after comparison
+        pre_cached = cache.get_cached(binary_path)
+        pre_named = 0
+        if pre_cached:
+            for f in pre_cached.get("functions", []):
+                name = f.get("name", "") or ""
+                if name and not name.startswith("FUN_") and not f.get("is_thunk"):
+                    pre_named += 1
+            cache.invalidate(binary_path)
+
+        context = get_analysis_context(
+            binary_path,
+            force_reanalyze=True,
+            pdb_path=pdb_path,
+        )
+
+        post_functions = context.get("functions", [])
+        post_named = sum(
+            1 for f in post_functions
+            if (f.get("name") or "") and not (f.get("name") or "").startswith("FUN_")
+            and not f.get("is_thunk")
+        )
+
+        lines = [
+            f"**PDB applied to {Path(binary_path).name}**",
+            f"- PDB: {pdb_path}",
+            f"- Functions with symbolic names before: {pre_named}",
+            f"- Functions with symbolic names after: {post_named}",
+            f"- Gain: +{post_named - pre_named}",
+        ]
+        if post_named <= pre_named:
+            lines.append(
+                "\n⚠️  No gain detected. The PDB may not match this binary, "
+                "or Ghidra's PdbUniversalAnalyzer did not run. Check the "
+                "debug log in the cache directory."
+            )
+        return "\n".join(lines)
+
+    except FileNotFoundError as e:
+        return f"PDB not found: {e}"
+    except (PathTraversalError, FileSizeError) as e:
+        return safe_error_message("Invalid binary or PDB path", e)
+    except Exception as e:
+        logger.exception(f"load_pdb failed: {e}")
+        return safe_error_message("Failed to apply PDB", e)
 
 
 @app.tool()
@@ -2977,7 +3061,13 @@ def main():
     # Register PE structure analysis tools
     register_pe_tools(app, session_manager)
 
-    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash, PE structure)")
+    # Register pseudocode-review + caller-analysis tools
+    register_review_tools(app, session_manager, cache, runner, api_patterns)
+
+    # Register Function ID (FID) library-match reader
+    register_fid_tools(app, session_manager, cache, runner)
+
+    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash, PE structure, review, fid)")
     logger.info(f"Session Directory: {session_manager.store_dir}")
 
     # Run the FastMCP server (handles stdio automatically)

--- a/src/server.py
+++ b/src/server.py
@@ -276,7 +276,14 @@ def get_analysis_context(
     binary_path: str,
     force_reanalyze: bool = False,
     processor: str | None = None,
-    loader: str | None = None
+    loader: str | None = None,
+    *,
+    skip_decompile: bool = False,
+    max_functions: int | None = None,
+    function_timeout: int | None = None,
+    incremental: bool = False,
+    start_address: str | None = None,
+    end_address: str | None = None,
 ) -> dict:
     """
     Get or create analysis context for a binary.
@@ -286,6 +293,17 @@ def get_analysis_context(
         force_reanalyze: Force re-analysis even if cached
         processor: Optional processor specification (e.g., "x86:LE:64:default")
         loader: Optional loader name (e.g., "PeLoader" for Windows PE, "ElfLoader" for Linux ELF)
+        skip_decompile: Skip per-function decompilation for a much faster
+            structural pass (no pseudocode). Useful for large binaries where
+            decompilation dominates wall-clock time.
+        max_functions: Cap how many functions the Jython script will process
+            this run (useful with ``incremental`` for chunked coverage).
+        function_timeout: Per-function decompilation timeout in seconds.
+        incremental: When True and a cache already exists, pass it to Ghidra
+            as ``resume_from_cache`` so the script skips previously-analyzed
+            functions and extends coverage rather than restarting.
+        start_address / end_address: Hex bounds used to restrict the run to a
+            sub-range (``"0x61abbc"``). Pairs well with ``incremental``.
 
     Returns:
         Analysis context dict
@@ -310,8 +328,11 @@ def get_analysis_context(
         logger.error(f"Path validation failed: {e}")
         raise RuntimeError(f"Invalid binary path: {e}")
 
-    # Check cache first (skip cache if processor/loader specified)
-    if not force_reanalyze and not processor and not loader:
+    # Short-circuit to cache unless the caller asked to re-analyze,
+    # is overriding the processor/loader, or is extending coverage via
+    # incremental/range options.
+    extending = incremental or start_address or end_address
+    if not force_reanalyze and not processor and not loader and not extending:
         cached_context = cache.get_cached(binary_path)
         if cached_context:
             logger.info(f"Using cached analysis for {binary_path}")
@@ -325,10 +346,19 @@ def get_analysis_context(
     output_path = cache.cache_dir / f"temp_analysis_{Path(binary_path).stem}.json"
     script_path = Path(__file__).parent / "engines" / "static" / "ghidra" / "scripts"
 
+    # Resolve resume path if caller wants to extend an existing cache
+    resume_from_cache = None
+    if incremental:
+        resume_from_cache = cache.get_cache_path(binary_path)
+        if resume_from_cache is None:
+            logger.info("incremental=True but no cache exists yet; running full analysis")
+        else:
+            logger.info(f"Resuming analysis from cache: {resume_from_cache}")
+
     try:
-        # Use configurable timeout (default 600 seconds / 10 minutes)
-        # Bounds: minimum 30s, maximum 3600s (1 hour)
-        timeout = get_config_int("GHIDRA_TIMEOUT", 600)
+        # Default bumped to 1800s (30 min) — large binaries routinely need more
+        # than the old 10-minute ceiling. Bounds are still 30s..3600s.
+        timeout = get_config_int("GHIDRA_TIMEOUT", 1800)
         timeout = validate_numeric_range(timeout, 30, 3600, "GHIDRA_TIMEOUT")
         result = runner.analyze(
             binary_path=binary_path,
@@ -338,7 +368,13 @@ def get_analysis_context(
             keep_project=True,  # Keep project for incremental analysis
             timeout=timeout,
             processor=processor,
-            loader=loader
+            loader=loader,
+            skip_decompile=skip_decompile,
+            max_functions=max_functions,
+            function_timeout=function_timeout,
+            resume_from_cache=str(resume_from_cache) if resume_from_cache else None,
+            start_address=start_address,
+            end_address=end_address,
         )
 
         # Save Ghidra output to debug file for inspection
@@ -450,7 +486,13 @@ def analyze_binary(
     force_reanalyze: bool = False,
     processor: str | None = None,
     loader: str | None = None,
-    skip_compatibility_check: bool = False
+    skip_compatibility_check: bool = False,
+    skip_decompile: bool = False,
+    max_functions: int | None = None,
+    function_timeout: int | None = None,
+    incremental: bool = False,
+    start_address: str | None = None,
+    end_address: str | None = None,
 ) -> str:
     """
     Analyze a binary file with Ghidra headless analyzer.
@@ -468,6 +510,17 @@ def analyze_binary(
         processor: Optional processor spec when AutoImporter fails (e.g., "x86:LE:64:default")
         loader: Optional loader name when AutoImporter fails (e.g., "PeLoader" for Windows PE)
         skip_compatibility_check: Skip pre-analysis compatibility check (default: False)
+        skip_decompile: Skip decompilation for a fast structural pass (no pseudocode).
+            Recommended for a first pass on very large binaries — functions,
+            imports, strings, and memory map are still extracted.
+        max_functions: Cap how many functions to process this run (pairs with
+            ``incremental`` for multi-pass coverage of huge binaries).
+        function_timeout: Per-function decompile timeout (seconds). Lower values
+            skip anti-analysis code faster.
+        incremental: When True, extend an existing cache instead of starting
+            fresh. Previously-analyzed functions are skipped and preserved.
+        start_address / end_address: Hex bounds to restrict the run to an
+            address range (e.g. ``"0x61abbc"``).
 
     Returns:
         Analysis summary with basic statistics, or compatibility warning if issues detected
@@ -479,6 +532,11 @@ def analyze_binary(
         - For macOS Mach-O: processor="x86:LE:64:default", loader="MachoLoader"
 
         Common Ghidra loaders: PeLoader, ElfLoader, MachoLoader, BinaryLoader, CoffLoader
+
+        Large-binary workflow (e.g. 17MB+ with 60K+ functions):
+        1. First pass: ``analyze_binary(..., skip_decompile=True)`` — structure only.
+        2. Extend: ``analyze_binary(..., incremental=True, max_functions=5000)``
+           repeatedly, or target a range with ``start_address``/``end_address``.
     """
     # Store compatibility info for inclusion in output
     compat_warning = None
@@ -508,7 +566,18 @@ Format: {compat_info.format.value}
                 # Don't fail on compatibility check errors, just log and proceed
                 logger.warning(f"Compatibility check failed, proceeding with analysis: {e}")
 
-        context = get_analysis_context(binary_path, force_reanalyze, processor, loader)
+        context = get_analysis_context(
+            binary_path,
+            force_reanalyze,
+            processor,
+            loader,
+            skip_decompile=skip_decompile,
+            max_functions=max_functions,
+            function_timeout=function_timeout,
+            incremental=incremental,
+            start_address=start_address,
+            end_address=end_address,
+        )
 
         metadata = context.get("metadata", {})
         functions = context.get("functions", [])
@@ -556,6 +625,26 @@ Format: {compat_info.format.value}
             summary += "\n**Analysis Warnings:**\n"
             for warning in warnings:
                 summary += f"{warning}\n"
+
+        # Surface incremental / partial-run stats when present
+        stats = context.get("analysis_stats", {})
+        if stats.get("resumed") or stats.get("partial_results") or stats.get("skipped_by_range"):
+            summary += "\n**Analysis Run Stats:**\n"
+            if stats.get("resumed"):
+                summary += (
+                    f"- Resumed from prior cache: "
+                    f"{stats.get('resumed_from_count', 0)} functions preserved\n"
+                )
+            summary += f"- Functions processed this run: {stats.get('functions_analyzed', 0)}\n"
+            if stats.get("skipped_by_resume"):
+                summary += f"- Skipped (already in cache): {stats['skipped_by_resume']}\n"
+            if stats.get("skipped_by_range"):
+                summary += f"- Skipped (outside address range): {stats['skipped_by_range']}\n"
+            if stats.get("partial_results"):
+                summary += (
+                    "- ⚠️  Partial results — hit max_functions or wall-clock budget. "
+                    "Re-run with `incremental=True` to extend coverage.\n"
+                )
 
         summary += """
 Analysis cached for fast subsequent queries.

--- a/src/server.py
+++ b/src/server.py
@@ -948,60 +948,207 @@ def get_strings(
         return f"Error: {e}"
 
 
+def _normalize_xref_addr(raw: str | None) -> str:
+    """Normalize an address for xref comparison: lowercase, no 0x, no leading zeros."""
+    if not raw:
+        return ""
+    return str(raw).lower().replace("0x", "").lstrip("0") or "0"
+
+
 @app.tool()
 @log_to_session
 def get_xrefs(
     binary_path: str,
     address: str | None = None,
     function_name: str | None = None,
-    direction: str = "to"
+    direction: str = "to",
+    limit: int = 200,
 ) -> str:
     """
-    Get cross-references for an address or function.
+    Get cross-references for a function or arbitrary address.
+
+    Derives xrefs from the cached Ghidra context:
+      * Function-to-function calls (inverts ``called_functions`` for
+        ``direction="to"``, uses the function's own callee list for
+        ``direction="from"``).
+      * String xrefs (existing per-string ``xrefs`` list).
+      * Pseudocode-mention scan as a last resort, surfacing any function
+        whose decompiled body references the target address literal.
 
     Args:
         binary_path: Path to analyzed binary
-        address: Hex address to find xrefs for
-        function_name: Function name to find xrefs for
-        direction: "to" (references to) or "from" (references from)
+        address: Hex address to find xrefs for (e.g. "0x401000")
+        function_name: Convenience alternative to address — resolves to the
+            function's entry point
+        direction: "to" (references inbound) or "from" (outbound)
+        limit: Max xref rows to list (default 200)
 
     Returns:
-        List of cross-references with types
+        Structured listing grouped by xref source, or a clear "no xrefs"
+        message (never "coming soon").
     """
     try:
         context = get_analysis_context(binary_path)
+        functions = context.get("functions", [])
 
         if function_name:
-            # Find function by name
-            functions = context.get("functions", [])
-            function = next((f for f in functions if f.get('name') == function_name), None)
-
+            function = next(
+                (f for f in functions if f.get("name") == function_name), None
+            )
             if not function:
                 return f"Error: Function '{function_name}' not found"
-
-            address = function.get('address')
+            address = function.get("address")
 
         if not address:
             return "Error: Must provide either address or function_name"
 
-        # For now, show xrefs from strings
-        # Full xref implementation would need additional Ghidra script support
-        strings = context.get("strings", [])
+        if direction not in ("to", "from"):
+            return "Error: direction must be 'to' or 'from'"
 
-        result = f"**Cross-references {direction} {address}:**\n\n"
+        target_norm = _normalize_xref_addr(address)
+        target_fn = next(
+            (f for f in functions if _normalize_xref_addr(f.get("address")) == target_norm),
+            None,
+        )
 
-        found = False
-        for string in strings:
-            for xref in string.get('xrefs', []):
-                if (direction == "to" and xref.get('from') == address) or \
-                   (direction == "from" and string.get('address') == address):
-                    result += f"- {xref.get('from')} -> {string.get('address')}: {string.get('value', '')[:50]}\n"
-                    found = True
+        function_xrefs: list[dict] = []
+        string_xrefs: list[dict] = []
+        pseudocode_xrefs: list[dict] = []
 
-        if not found:
-            result += "*No cross-references found. Note: Full xref support coming soon.*\n"
+        # --- function-to-function xrefs ---------------------------------
+        if direction == "to":
+            # Who calls this address? Scan called_functions of every function.
+            for caller in functions:
+                for call in caller.get("called_functions") or []:
+                    if _normalize_xref_addr(call.get("address")) == target_norm:
+                        function_xrefs.append({
+                            "from": caller.get("address"),
+                            "from_name": caller.get("name"),
+                            "to": address,
+                            "type": "CALL",
+                        })
+                        break
+        else:  # from
+            if target_fn:
+                for call in target_fn.get("called_functions") or []:
+                    function_xrefs.append({
+                        "from": target_fn.get("address"),
+                        "from_name": target_fn.get("name"),
+                        "to": call.get("address"),
+                        "to_name": call.get("name"),
+                        "type": "CALL",
+                    })
 
-        return result
+        # --- string xrefs -----------------------------------------------
+        for s in context.get("strings", []):
+            s_addr_norm = _normalize_xref_addr(s.get("address"))
+            if direction == "to":
+                # Caller asked "what xrefs point AT <address>?" -- for strings
+                # that means: is <address> the location of a string referenced
+                # from this function's body?
+                if s_addr_norm == target_norm:
+                    for xref in s.get("xrefs") or []:
+                        string_xrefs.append({
+                            "from": xref.get("from"),
+                            "to": s.get("address"),
+                            "type": f"DATA/{xref.get('type', 'REF')}",
+                            "value": (s.get("value") or "")[:80],
+                        })
+            else:  # from
+                # Caller asked "what xrefs originate AT/inside this address?"
+                for xref in s.get("xrefs") or []:
+                    if _normalize_xref_addr(xref.get("from")) == target_norm:
+                        string_xrefs.append({
+                            "from": xref.get("from"),
+                            "to": s.get("address"),
+                            "type": f"DATA/{xref.get('type', 'REF')}",
+                            "value": (s.get("value") or "")[:80],
+                        })
+
+        # --- pseudocode mention scan (last resort, direction=to only) ---
+        if direction == "to" and not function_xrefs and not string_xrefs:
+            needle_forms = {f"0x{target_norm}", f"0x{target_norm.zfill(8)}"}
+            for caller in functions:
+                pseudo = caller.get("pseudocode") or ""
+                if any(n in pseudo for n in needle_forms):
+                    pseudocode_xrefs.append({
+                        "from": caller.get("address"),
+                        "from_name": caller.get("name"),
+                        "type": "PSEUDOCODE_MENTION",
+                    })
+
+        total = len(function_xrefs) + len(string_xrefs) + len(pseudocode_xrefs)
+        if total == 0:
+            target_label = (
+                f"{target_fn.get('name')} @ {address}" if target_fn else address
+            )
+            return (
+                f"**Cross-references {direction} {target_label}:**\n\n"
+                f"*No xrefs found. This function may only be reached via "
+                f"indirect calls (vtable / function pointer) which are not "
+                f"resolved in the current extraction.*"
+            )
+
+        # Format output grouped by type
+        target_label = f"{target_fn.get('name')} @ {address}" if target_fn else address
+        lines = [f"**Cross-references {direction} {target_label}:**", ""]
+        lines.append(f"Total: {total}")
+        lines.append("")
+
+        shown = 0
+        if function_xrefs:
+            lines.append(f"### Function calls ({len(function_xrefs)})")
+            for x in function_xrefs:
+                if shown >= limit:
+                    break
+                if direction == "to":
+                    lines.append(
+                        f"- {x['from_name']} @ {x['from']}  [{x['type']}]"
+                    )
+                else:
+                    to_name = x.get("to_name") or "?"
+                    lines.append(
+                        f"- {x['from_name']} @ {x['from']}  ->  "
+                        f"{to_name} @ {x['to']}  [{x['type']}]"
+                    )
+                shown += 1
+            lines.append("")
+
+        if string_xrefs and shown < limit:
+            lines.append(f"### Data / string refs ({len(string_xrefs)})")
+            for x in string_xrefs:
+                if shown >= limit:
+                    break
+                lines.append(
+                    f"- {x['from']}  ->  {x['to']}  [{x['type']}]  "
+                    f"`{x['value']}`"
+                )
+                shown += 1
+            lines.append("")
+
+        if pseudocode_xrefs and shown < limit:
+            lines.append(
+                f"### Pseudocode mentions ({len(pseudocode_xrefs)})"
+            )
+            lines.append(
+                "_Function bodies that textually mention this address "
+                "(may include indirect-call resolutions)._"
+            )
+            for x in pseudocode_xrefs:
+                if shown >= limit:
+                    break
+                lines.append(
+                    f"- {x['from_name']} @ {x['from']}  [{x['type']}]"
+                )
+                shown += 1
+
+        if total > limit:
+            lines.append("")
+            lines.append(
+                f"*Showing {limit} of {total}. Increase `limit` to see more.*"
+            )
+
+        return "\n".join(lines)
 
     except Exception as e:
         logger.error(f"get_xrefs failed: {e}")

--- a/src/tools/control_flow_tools.py
+++ b/src/tools/control_flow_tools.py
@@ -122,8 +122,13 @@ def _parse_capstone_arch(metadata: dict):
     """
     Determine capstone architecture constants from Ghidra metadata.
 
-    The ``language`` field from Ghidra looks like ``x86:LE:64:default``,
-    ``ARM:LE:32:v7``, ``AARCH64:LE:64:v8A``, etc.
+    Accepts three shapes of ``language`` field for backward compatibility:
+    1. Canonical Ghidra LanguageID: ``x86:LE:64:default``, ``ARM:LE:32:v7``,
+       ``AARCH64:LE:64:v8A`` (current format).
+    2. Description string from ``Language.toString()`` — older caches stored
+       this instead of the canonical ID. Parsed by keyword.
+    3. Empty / unparseable — falls through to ``executable_format`` keyword
+       inspection so PE/ELF-64 binaries still get x86-64 disassembly.
 
     Returns:
         Tuple of (cs_arch, cs_mode) or (None, None) if unsupported.
@@ -143,24 +148,49 @@ def _parse_capstone_arch(metadata: dict):
 
     lang = str(metadata.get("language", "")).upper()
 
-    # Parse Ghidra language id:  PROCESSOR:ENDIAN:SIZE:VARIANT
+    # --- Path 1: canonical colon-delimited ID -----------------------------
     parts = lang.split(":")
-    if len(parts) < 3:
-        return None, None
+    if len(parts) >= 3:
+        processor = parts[0]
+        bitness_str = parts[2]
+        if processor == "X86":
+            mode = CS_MODE_64 if bitness_str == "64" else CS_MODE_32
+            return CS_ARCH_X86, mode
+        if processor == "ARM" and bitness_str == "32":
+            return CS_ARCH_ARM, CS_MODE_ARM | CS_MODE_LITTLE_ENDIAN
+        if processor in ("AARCH64", "ARM") and bitness_str == "64":
+            return CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN
 
-    processor = parts[0]
-    bitness_str = parts[2]
+    # --- Path 2: description keyword match --------------------------------
+    # Covers Ghidra Language.toString() output plus older caches where the
+    # field was a mix of language info.
+    haystack = " ".join(
+        str(metadata.get(k, "")) for k in ("language", "language_description")
+    ).upper()
+    has_64 = "64" in haystack or "X86-64" in haystack or "AMD64" in haystack
 
-    if processor == "X86":
-        arch = CS_ARCH_X86
-        mode = CS_MODE_64 if bitness_str == "64" else CS_MODE_32
-        return arch, mode
-
-    if processor == "ARM" and bitness_str == "32":
-        return CS_ARCH_ARM, CS_MODE_ARM | CS_MODE_LITTLE_ENDIAN
-
-    if processor in ("AARCH64", "ARM") and bitness_str == "64":
+    if "AARCH64" in haystack or "ARM64" in haystack:
         return CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN
+    if "ARM" in haystack:
+        return CS_ARCH_ARM, CS_MODE_ARM | CS_MODE_LITTLE_ENDIAN
+    if "X86" in haystack or "X64" in haystack or "INTEL" in haystack:
+        return CS_ARCH_X86, CS_MODE_64 if has_64 else CS_MODE_32
+
+    # --- Path 3: executable_format fallback -------------------------------
+    # If the language field is useless, try to infer from the binary format.
+    # PE + 64-bit image_base >= 0x100000000 is a strong x86-64 signal.
+    exe_fmt = str(metadata.get("executable_format", "")).upper()
+    image_base_raw = str(metadata.get("image_base", "")).lower().replace("0x", "")
+    try:
+        image_base = int(image_base_raw, 16) if image_base_raw else 0
+    except ValueError:
+        image_base = 0
+
+    # PE is overwhelmingly x86/x64; image_base > 4GB is the classic PE32+
+    # signal for 64-bit. ELF gets no format fallback because ARM/MIPS/RISC-V
+    # ELFs would be mis-detected as x86.
+    if "PORTABLE EXECUTABLE" in exe_fmt or "PE " in exe_fmt or exe_fmt == "PE":
+        return CS_ARCH_X86, CS_MODE_64 if image_base > 0xFFFFFFFF else CS_MODE_32
 
     return None, None
 

--- a/src/tools/dynamic_tools.py
+++ b/src/tools/dynamic_tools.py
@@ -2070,7 +2070,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
                 return "No stack frames available"
 
             if is_raw:
-                header = f"Stack contents (raw dump, not unwound call stack) — {len(frames)} entries:"
+                header = f"Stack contents (raw dump, not unwound call stack) -- {len(frames)} entries:"
             else:
                 header = f"Call Stack ({len(frames)} frames):"
 
@@ -3782,7 +3782,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
         "setwatchexpression", "setwatchname",
         # DLL breakpoints
         "bpdll", "bcdll", "bpedll", "bpddll",
-        # Trace configuration — tracesetcommand, tracesetlog, tracesetlogfile
+        # Trace configuration -- tracesetcommand, tracesetlog, tracesetlogfile
         # are intentionally EXCLUDED from this allowlist because their arguments
         # (arbitrary commands, file paths) bypass security validation. Use the
         # dedicated tools x64dbg_set_trace_command and x64dbg_set_trace_log_file
@@ -7990,14 +7990,14 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
         Args:
             index: Zero-based watch index
             mode: Trigger mode. One of:
-                  "changed" — value changed (default)
-                  "disabled" — watchdog off
-                  "unchanged" — value unchanged
-                  "istrue" — value is non-zero
-                  "isfalse" — value is zero
-                  "isgreater" — value increased
-                  "isless" — value decreased
-                  "isnotequal" — value differs from initial
+                  "changed" -- value changed (default)
+                  "disabled" -- watchdog off
+                  "unchanged" -- value unchanged
+                  "istrue" -- value is non-zero
+                  "isfalse" -- value is zero
+                  "isgreater" -- value increased
+                  "isless" -- value decreased
+                  "isnotequal" -- value differs from initial
 
         Returns:
             Confirmation message
@@ -8658,7 +8658,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
         """
         Overlay a struct/type on a memory address for structured viewing.
 
-        This is the key type system tool — it interprets raw memory at the
+        This is the key type system tool -- it interprets raw memory at the
         given address as the specified struct type, showing field names and values.
 
         Args:
@@ -9094,7 +9094,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
 
         Uses x64dbg's trace-into-beyond-record (tibt) which tracks all executed
         addresses and stops when execution reaches a never-before-seen address
-        region — typically the OEP after unpacking completes.
+        region -- typically the OEP after unpacking completes.
 
         Args:
             max_steps: Maximum trace steps (default: 50000, increase for complex packers)
@@ -9146,7 +9146,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
 
         Args:
             text: Log format string with x64dbg specifiers
-            condition: Optional condition — only log when this expression is true
+            condition: Optional condition -- only log when this expression is true
 
         Returns:
             Confirmation message
@@ -9157,10 +9157,10 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
             x64dbg_set_trace_log("ESP={esp} [ESP]={[esp]}")
 
         Format Specifiers:
-            {rax}, {rbx}, etc. — register values
-            {[esp]}, {[rax+8]} — memory dereference
-            {dis.sel()} — disassembly at current address
-            {mem;addr;size} — memory dump
+            {rax}, {rbx}, etc. -- register values
+            {[esp]}, {[rax+8]} -- memory dereference
+            {dis.sel()} -- disassembly at current address
+            {mem;addr;size} -- memory dump
         """
         try:
             if not text or not text.strip():
@@ -9191,7 +9191,7 @@ def register_dynamic_tools(app: FastMCP, session_manager: UnifiedSessionManager 
 
         Args:
             command: x64dbg command to execute per step
-            condition: Optional condition — only run when this expression is true
+            condition: Optional condition -- only run when this expression is true
 
         Returns:
             Confirmation message

--- a/src/tools/fid_tools.py
+++ b/src/tools/fid_tools.py
@@ -1,0 +1,122 @@
+"""
+Function ID (FID) library-match reporting tool.
+
+FID matching happens inside ``core_analysis.py`` when ``enable_fid=True`` is
+passed to ``analyze_binary``. This module just formats the results from the
+cache. Keeping the reader separate from the analysis step means users can
+query matches without re-running Ghidra.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.utils.security import (
+    FileSizeError,
+    PathTraversalError,
+    sanitize_binary_path,
+    validate_numeric_range,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def register_fid_tools(app, session_manager, cache, runner):
+    """Register fid_match MCP tool on the given FastMCP app."""
+
+    @app.tool()
+    def fid_match(
+        binary_path: str,
+        filter_unmatched: bool = True,
+        limit: int = 100,
+    ) -> str:
+        """
+        List functions identified by Ghidra's Function ID library database.
+
+        Requires a prior run of ``analyze_binary(path, enable_fid=True)``.
+        Matches are stored per-function as the ``fid_match`` field in the
+        cache. Useful for filtering out stdlib / CRT noise so your review
+        focuses on binary-specific code.
+
+        Args:
+            binary_path: Path to analyzed binary
+            filter_unmatched: When True (default), only list functions that
+                actually matched a FID entry
+            limit: Max rows returned (default 100, max 10000)
+
+        Returns:
+            Formatted table, or guidance to re-run with ``enable_fid=True``.
+        """
+        try:
+            limit = validate_numeric_range(limit, 1, 10000, "limit")
+            validated = sanitize_binary_path(binary_path)
+            bp = str(validated)
+
+            cached = cache.get_cached(bp)
+            if not cached:
+                return (
+                    "No cached analysis. Run "
+                    "`analyze_binary(path, enable_fid=True)` first."
+                )
+
+            functions = cached.get("functions", [])
+            # Detect whether FID ran at all
+            has_fid_field = any("fid_match" in f for f in functions)
+            if not has_fid_field:
+                return (
+                    "Cache has no fid_match data. Re-run "
+                    "`analyze_binary(path, force_reanalyze=True, enable_fid=True)` "
+                    "to populate Function ID matches."
+                )
+
+            rows: list[tuple[dict, dict]] = []
+            matched_count = 0
+            unmatched_count = 0
+            for func in functions:
+                m = func.get("fid_match")
+                if m:
+                    matched_count += 1
+                    rows.append((func, m))
+                else:
+                    unmatched_count += 1
+                    if not filter_unmatched:
+                        rows.append((func, {}))
+
+            total = len(rows)
+            rows = rows[:limit]
+
+            header = [
+                f"**FID matches: {matched_count} matched / {unmatched_count} unmatched**",
+                f"Showing {len(rows)} of {total}",
+                "",
+            ]
+            if matched_count == 0:
+                header.append(
+                    "No FID matches found. Either FID databases are not "
+                    "installed, the language is unsupported, or the binary "
+                    "contains no recognised library functions."
+                )
+                return "\n".join(header)
+
+            lines = header
+            for func, m in rows:
+                orig_name = func.get("name") or ""
+                addr = func.get("address") or ""
+                if m:
+                    conf = m.get("confidence")
+                    conf_str = f"{conf:.1f}" if isinstance(conf, (int, float)) else "?"
+                    lines.append(
+                        f"- {addr}  `{orig_name}`  →  "
+                        f"{m.get('name', '?')}  [{m.get('library', '?')}, score={conf_str}]"
+                    )
+                else:
+                    lines.append(f"- {addr}  `{orig_name}`  (no match)")
+            return "\n".join(lines)
+
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as e:
+            return f"Invalid binary path: {e}"
+        except Exception as e:
+            logger.exception(f"fid_match failed: {e}")
+            return f"Error: {e}"
+
+    return (fid_match,)

--- a/src/tools/function_hash_tools.py
+++ b/src/tools/function_hash_tools.py
@@ -797,7 +797,7 @@ def register_function_hash_tools(app, session_manager, cache, runner):
                             matched_b_names.add(name_b)
                             break
 
-            # Fuzzy matching for remaining functions — use bisect for size windowing
+            # Fuzzy matching for remaining functions -- use bisect for size windowing
             fuzzy_matches = []
             remaining_a = {
                 n: v for n, v in hashes_a.items() if n not in matched_a_names
@@ -843,7 +843,7 @@ def register_function_hash_tools(app, session_manager, cache, runner):
                     max_cc = max(cc_a, cc_b)
                     call_sim = 1.0 - (abs(cc_a - cc_b) / max_cc) if max_cc > 0 else 1.0
 
-                    # Called function name overlap (import overlap) — pre-computed frozensets
+                    # Called function name overlap (import overlap) -- pre-computed frozensets
                     set_a = info_a["called_functions"]
                     set_b = info_b["called_functions"]
                     if set_a and set_b:

--- a/src/tools/malware_tools.py
+++ b/src/tools/malware_tools.py
@@ -325,7 +325,7 @@ API_CALL_CHAINS = [
     {
         "name": "File Enumeration + Encryption (Ransomware)",
         "severity": "critical",
-        "description": "Enumerates files and encrypts them — strong ransomware indicator",
+        "description": "Enumerates files and encrypts them -- strong ransomware indicator",
         "chain": ["FindFirstFile", "FindNextFile", "CryptEncrypt"],
         "min_match": 2,
     },

--- a/src/tools/pe_tools.py
+++ b/src/tools/pe_tools.py
@@ -466,7 +466,7 @@ def _parse_bound_imports(pe) -> list[str]:
 
 
 def _parse_exceptions(pe) -> list[str]:
-    """Parse exception directory — x64 RUNTIME_FUNCTION entries (full detail only)."""
+    """Parse exception directory -- x64 RUNTIME_FUNCTION entries (full detail only)."""
     lines = ["--- Exception Handlers ---"]
     if not hasattr(pe, "DIRECTORY_ENTRY_EXCEPTION") or not pe.DIRECTORY_ENTRY_EXCEPTION:
         lines.append("No exception directory")
@@ -527,7 +527,7 @@ def register_pe_tools(app, session_manager=None):
         Get comprehensive PE file structure information.
 
         Returns complete PE headers, sections, imports, exports, resources,
-        debug info, TLS, Rich header, and more — all from a single fast call
+        debug info, TLS, Rich header, and more -- all from a single fast call
         using pefile (no Ghidra dependency).
 
         Args:

--- a/src/tools/review_tools.py
+++ b/src/tools/review_tools.py
@@ -1,7 +1,7 @@
 """
 Review and caller-analysis tools backed by the cached Ghidra context.
 
-These tools never spawn Ghidra — they operate purely on the cache populated
+These tools never spawn Ghidra -- they operate purely on the cache populated
 by ``analyze_binary``. If a binary has not been analyzed yet, they run it
 once through the cache-miss path (mirroring the pattern used by
 ``control_flow_tools._get_or_run_analysis``).
@@ -22,7 +22,7 @@ from src.utils.security import (
 
 logger = logging.getLogger(__name__)
 
-# One module-level rules instance — pattern compilation is non-trivial and
+# One module-level rules instance -- pattern compilation is non-trivial and
 # the rules are stateless.
 _RULES = PseudocodeRules()
 
@@ -148,7 +148,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
 
         Args:
             binary_path: Path to analyzed binary
-            function_name_or_address: Target function — exact name, hex
+            function_name_or_address: Target function -- exact name, hex
                 address (with or without 0x), or unique substring match
             limit: Max callers to return (default 100, max 10000)
 
@@ -208,7 +208,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
         Scan cached pseudocode for CWE / vulnerability patterns.
 
         Applies a curated rule set (see ``src/utils/pseudocode_rules.py``) to
-        every function's decompiled output. Pattern-based triage — expect
+        every function's decompiled output. Pattern-based triage -- expect
         false positives; use findings as starting points, not verdicts.
 
         Args:
@@ -284,7 +284,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
             for hit in all_findings:
                 lines.append(
                     f"[{hit['severity'].upper()}] {hit['rule_id']} ({hit['cwe']}) "
-                    f"— {hit['function']} @ {hit['address']}"
+                    f"-- {hit['function']} @ {hit['address']}"
                 )
                 lines.append(f"    {hit['description']}")
                 lines.append(f"    excerpt: {hit['excerpt']}")
@@ -353,7 +353,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
                         apis_used.append(api)
 
             # Strings referenced at addresses inside this function's body
-            # (cheap: each string has xrefs with a "from" address — compare
+            # (cheap: each string has xrefs with a "from" address -- compare
             # against the function's basic-block ranges)
             strings_referenced: list[dict] = []
             func_ranges = []
@@ -389,7 +389,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
 
             # Format
             lines = [
-                f"# Review Package — {target.get('name')} @ {target.get('address')}",
+                f"# Review Package -- {target.get('name')} @ {target.get('address')}",
                 "",
                 "## Signature",
                 f"`{signature}`",
@@ -418,7 +418,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
                 if len(callers) > 25:
                     lines.append(f"  … and {len(callers) - 25} more")
             else:
-                lines.append("(none — entry point or unreferenced)")
+                lines.append("(none -- entry point or unreferenced)")
 
             lines.append("")
             lines.append("## Callees")
@@ -482,7 +482,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
                 lines.append("```")
             else:
                 lines.append(
-                    "(no pseudocode — function was likely analyzed with "
+                    "(no pseudocode -- function was likely analyzed with "
                     "skip_decompile=True or is a thunk/external)"
                 )
 
@@ -542,7 +542,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
 
             if not any_has_field:
                 return (
-                    "No jump_tables data in cache — this cache was produced "
+                    "No jump_tables data in cache -- this cache was produced "
                     "by a version of core_analysis.py that predates jump-table "
                     "extraction. Re-run `analyze_binary(path, force_reanalyze=True)`."
                 )
@@ -557,7 +557,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
             for func, jt in tables:
                 targets = jt.get("targets") or []
                 lines.append(
-                    f"- {func.get('name')} @ {func.get('address')} — "
+                    f"- {func.get('name')} @ {func.get('address')} -- "
                     f"switch @ {jt.get('source_addr')} → {len(targets)} cases"
                 )
                 for t in targets[:12]:

--- a/src/tools/review_tools.py
+++ b/src/tools/review_tools.py
@@ -1,0 +1,581 @@
+"""
+Review and caller-analysis tools backed by the cached Ghidra context.
+
+These tools never spawn Ghidra — they operate purely on the cache populated
+by ``analyze_binary``. If a binary has not been analyzed yet, they run it
+once through the cache-miss path (mirroring the pattern used by
+``control_flow_tools._get_or_run_analysis``).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from src.utils.pseudocode_rules import PseudocodeRules, scan_text
+from src.utils.security import (
+    FileSizeError,
+    PathTraversalError,
+    sanitize_binary_path,
+    validate_numeric_range,
+)
+
+logger = logging.getLogger(__name__)
+
+# One module-level rules instance — pattern compilation is non-trivial and
+# the rules are stateless.
+_RULES = PseudocodeRules()
+
+
+# -- shared helpers ---------------------------------------------------------
+
+def _normalize_addr(raw: str | None) -> str:
+    """Normalize an address string for comparison: lowercase, no 0x, no leading zeros."""
+    if not raw:
+        return ""
+    return str(raw).lower().replace("0x", "").lstrip("0") or "0"
+
+
+def _find_function(functions: list[dict], name_or_address: str) -> dict | None:
+    """Look up a function by exact name, address, or substring name match."""
+    for f in functions:
+        if f.get("name") == name_or_address:
+            return f
+
+    needle = _normalize_addr(name_or_address)
+    for f in functions:
+        if _normalize_addr(f.get("address")) == needle:
+            return f
+
+    lower = name_or_address.lower()
+    for f in functions:
+        if lower in (f.get("name") or "").lower():
+            return f
+    return None
+
+
+def _build_caller_index(functions: list[dict]) -> dict[str, list[dict]]:
+    """
+    Invert ``called_functions`` → map of callee-address → list of callers.
+
+    O(N) scan across all functions; at 22K functions × ~10 callees/function
+    this is under 5ms.
+    """
+    index: dict[str, list[dict]] = {}
+    for caller in functions:
+        caller_meta = {
+            "name": caller.get("name"),
+            "address": caller.get("address"),
+        }
+        for call in caller.get("called_functions", []) or []:
+            addr = _normalize_addr(call.get("address"))
+            if not addr:
+                continue
+            index.setdefault(addr, []).append(caller_meta)
+    return index
+
+
+def _load_context(binary_path: str, cache, runner):
+    """Cache lookup with run-on-miss, mirroring control_flow_tools pattern."""
+    import json
+
+    from src.utils.config import get_config_int
+
+    validated = sanitize_binary_path(binary_path)
+    bp = str(validated)
+
+    cached = cache.get_cached(bp)
+    if cached:
+        return cached, bp
+
+    output_path = cache.cache_dir / f"temp_analysis_{Path(bp).stem}.json"
+    script_path = (
+        Path(__file__).parent.parent
+        / "engines"
+        / "static"
+        / "ghidra"
+        / "scripts"
+    )
+    timeout = get_config_int("GHIDRA_TIMEOUT", 1800)
+    timeout = validate_numeric_range(timeout, 30, 3600, "GHIDRA_TIMEOUT")
+
+    runner.analyze(
+        binary_path=bp,
+        script_path=str(script_path),
+        script_name="core_analysis.py",
+        output_path=str(output_path),
+        keep_project=True,
+        timeout=timeout,
+    )
+    if not output_path.exists():
+        raise RuntimeError("Ghidra did not produce output.")
+
+    with open(output_path, encoding="utf-8") as f:
+        context = json.load(f)
+    cache.save_cached(bp, context)
+    output_path.unlink(missing_ok=True)
+    return context, bp
+
+
+# -- registration -----------------------------------------------------------
+
+def register_review_tools(app, session_manager, cache, runner, api_patterns=None):
+    """
+    Register review-oriented MCP tools.
+
+    Args:
+        app: FastMCP instance
+        session_manager: unused today; kept for signature parity with other
+            tool modules in case session-logging is added later
+        cache: ProjectCache
+        runner: GhidraRunner
+        api_patterns: APIPatterns instance (optional) used by
+            ``get_review_package`` to enrich the API-usage list
+    """
+
+    @app.tool()
+    def get_function_callers(
+        binary_path: str,
+        function_name_or_address: str,
+        limit: int = 100,
+    ) -> str:
+        """
+        List the functions that call a given function.
+
+        Inverts the cached ``called_functions`` graph. Useful for impact
+        analysis ("where is this handler invoked from?") which the existing
+        `get_call_graph` tool does not cover in the reverse direction.
+
+        Args:
+            binary_path: Path to analyzed binary
+            function_name_or_address: Target function — exact name, hex
+                address (with or without 0x), or unique substring match
+            limit: Max callers to return (default 100, max 10000)
+
+        Returns:
+            Formatted list of callers with addresses, or a not-found error.
+        """
+        try:
+            limit = validate_numeric_range(limit, 1, 10000, "limit")
+            context, _ = _load_context(binary_path, cache, runner)
+            functions = context.get("functions", [])
+
+            target = _find_function(functions, function_name_or_address)
+            if not target:
+                return (
+                    f"Function not found: {function_name_or_address}. "
+                    f"Try an exact name or address like '0x1800abcd'."
+                )
+
+            index = _build_caller_index(functions)
+            callers = index.get(_normalize_addr(target.get("address")), [])
+            total = len(callers)
+            shown = callers[:limit]
+
+            lines = [
+                f"**Callers of {target.get('name')} @ {target.get('address')}**",
+                f"Total: {total} (showing {len(shown)})",
+                "",
+            ]
+            if not shown:
+                lines.append("No callers found in this binary.")
+                lines.append(
+                    "Note: indirect calls (vtable/function pointer) are not "
+                    "resolved in the current extraction."
+                )
+            else:
+                for caller in shown:
+                    lines.append(
+                        f"- {caller.get('name')} @ {caller.get('address')}"
+                    )
+            return "\n".join(lines)
+
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as e:
+            return f"Invalid binary path: {e}"
+        except Exception as e:
+            logger.exception(f"get_function_callers failed: {e}")
+            return f"Error: {e}"
+
+    @app.tool()
+    def scan_pseudocode(
+        binary_path: str,
+        function_filter: str | None = None,
+        severity_floor: str = "low",
+        rule_ids: list[str] | None = None,
+        limit: int = 50,
+    ) -> str:
+        """
+        Scan cached pseudocode for CWE / vulnerability patterns.
+
+        Applies a curated rule set (see ``src/utils/pseudocode_rules.py``) to
+        every function's decompiled output. Pattern-based triage — expect
+        false positives; use findings as starting points, not verdicts.
+
+        Args:
+            binary_path: Path to analyzed binary (must have been analyzed
+                without ``skip_decompile=True``)
+            function_filter: Optional regex filtered against function names
+            severity_floor: "info" | "low" | "medium" | "high" | "critical"
+                (default "low")
+            rule_ids: Restrict scanning to specific rule ids
+            limit: Max findings to return (default 50, max 5000)
+
+        Returns:
+            Formatted findings grouped by function, sorted by severity.
+        """
+        try:
+            import re as _re
+
+            limit = validate_numeric_range(limit, 1, 5000, "limit")
+            context, _ = _load_context(binary_path, cache, runner)
+            functions = context.get("functions", [])
+
+            pattern = _re.compile(function_filter) if function_filter else None
+            rules = _RULES.filter(
+                severity_floor=severity_floor, rule_ids=rule_ids
+            )
+            if not rules:
+                return (
+                    f"No rules matched severity_floor={severity_floor} / "
+                    f"rule_ids={rule_ids}. See PseudocodeRules for available rules."
+                )
+
+            severity_order = {
+                s: i for i, s in enumerate(
+                    ("info", "low", "medium", "high", "critical")
+                )
+            }
+
+            all_findings: list[dict] = []
+            scanned = 0
+            for func in functions:
+                if pattern and not pattern.search(func.get("name") or ""):
+                    continue
+                pseudo = func.get("pseudocode")
+                if not pseudo:
+                    continue
+                scanned += 1
+                for finding in scan_text(pseudo, rules):
+                    finding["function"] = func.get("name")
+                    finding["address"] = func.get("address")
+                    all_findings.append(finding)
+
+            # Sort by severity descending, then by rule id for determinism
+            all_findings.sort(
+                key=lambda f: (
+                    -severity_order.get(f["severity"], 0),
+                    f["rule_id"],
+                )
+            )
+            total = len(all_findings)
+            all_findings = all_findings[:limit]
+
+            if not all_findings:
+                return (
+                    f"No findings. Scanned {scanned} functions with "
+                    f"{len(rules)} rules at severity_floor='{severity_floor}'."
+                )
+
+            lines = [
+                f"**Pseudocode scan: {total} finding(s) across {scanned} function(s)**",
+                f"Rules: {len(rules)} | Severity floor: {severity_floor}",
+                "",
+            ]
+            for hit in all_findings:
+                lines.append(
+                    f"[{hit['severity'].upper()}] {hit['rule_id']} ({hit['cwe']}) "
+                    f"— {hit['function']} @ {hit['address']}"
+                )
+                lines.append(f"    {hit['description']}")
+                lines.append(f"    excerpt: {hit['excerpt']}")
+                lines.append(f"    → {hit['recommendation']}")
+                lines.append("")
+            return "\n".join(lines)
+
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as e:
+            return f"Invalid binary path: {e}"
+        except Exception as e:
+            logger.exception(f"scan_pseudocode failed: {e}")
+            return f"Error: {e}"
+
+    @app.tool()
+    def get_review_package(
+        binary_path: str,
+        function_name_or_address: str,
+    ) -> str:
+        """
+        Assemble a self-contained review bundle for one function.
+
+        Returns pseudocode together with everything needed for semantic
+        review in one shot: callers, callees, imported APIs actually used,
+        referenced strings, jump tables (if extracted), pseudocode-rule
+        findings, and complexity. Hand the output to a model to get a
+        meaningful code review without further tool calls.
+
+        Args:
+            binary_path: Path to analyzed binary
+            function_name_or_address: Function to review
+
+        Returns:
+            Structured, multi-section text payload.
+        """
+        try:
+            context, _ = _load_context(binary_path, cache, runner)
+            functions = context.get("functions", [])
+
+            target = _find_function(functions, function_name_or_address)
+            if not target:
+                return f"Function not found: {function_name_or_address}."
+
+            pseudo = target.get("pseudocode") or ""
+            signature = target.get("signature") or ""
+            params = target.get("parameters") or []
+            locals_ = target.get("local_variables") or []
+            callees = target.get("called_functions") or []
+            basic_blocks = target.get("basic_blocks") or []
+            jump_tables = target.get("jump_tables") or []
+
+            caller_index = _build_caller_index(functions)
+            callers = caller_index.get(
+                _normalize_addr(target.get("address")), []
+            )
+
+            # APIs actually referenced in pseudocode
+            import_names: set[str] = set()
+            for imp in context.get("imports", []):
+                name = imp.get("name")
+                if name:
+                    import_names.add(name)
+            apis_used: list[str] = []
+            if pseudo:
+                for api in sorted(import_names):
+                    if api in pseudo:
+                        apis_used.append(api)
+
+            # Strings referenced at addresses inside this function's body
+            # (cheap: each string has xrefs with a "from" address — compare
+            # against the function's basic-block ranges)
+            strings_referenced: list[dict] = []
+            func_ranges = []
+            try:
+                for bb in basic_blocks:
+                    start = int(str(bb["start"]).replace("0x", ""), 16)
+                    end = int(str(bb["end"]).replace("0x", ""), 16)
+                    func_ranges.append((start, end))
+            except (KeyError, ValueError):
+                func_ranges = []
+
+            if func_ranges:
+                for s in context.get("strings", []):
+                    for xref in s.get("xrefs") or []:
+                        try:
+                            xa = int(
+                                str(xref.get("from", "")).replace("0x", ""), 16
+                            )
+                        except ValueError:
+                            continue
+                        if any(a <= xa <= b for a, b in func_ranges):
+                            strings_referenced.append({
+                                "address": s.get("address"),
+                                "value": (s.get("value") or "")[:120],
+                            })
+                            break
+
+            # Rule findings for this function only
+            findings: list[dict] = []
+            if pseudo:
+                for f in scan_text(pseudo, _RULES.rules):
+                    findings.append(f)
+
+            # Format
+            lines = [
+                f"# Review Package — {target.get('name')} @ {target.get('address')}",
+                "",
+                "## Signature",
+                f"`{signature}`",
+                "",
+                "## Metrics",
+                f"- Basic blocks: {len(basic_blocks)}",
+                f"- Parameters: {len(params)}",
+                f"- Local variables: {len(locals_)}",
+                f"- Callers: {len(callers)}",
+                f"- Callees: {len(callees)}",
+                f"- Jump tables: {len(jump_tables)}",
+                "",
+                "## Parameters",
+            ]
+            if params:
+                for p in params:
+                    lines.append(f"- `{p.get('datatype')} {p.get('name')}`")
+            else:
+                lines.append("(none)")
+
+            lines.append("")
+            lines.append("## Callers")
+            if callers:
+                for c in callers[:25]:
+                    lines.append(f"- {c.get('name')} @ {c.get('address')}")
+                if len(callers) > 25:
+                    lines.append(f"  … and {len(callers) - 25} more")
+            else:
+                lines.append("(none — entry point or unreferenced)")
+
+            lines.append("")
+            lines.append("## Callees")
+            if callees:
+                for c in callees[:25]:
+                    lines.append(f"- {c.get('name')} @ {c.get('address')}")
+                if len(callees) > 25:
+                    lines.append(f"  … and {len(callees) - 25} more")
+            else:
+                lines.append("(none)")
+
+            lines.append("")
+            lines.append("## Imported APIs referenced in pseudocode")
+            if apis_used:
+                for api in apis_used[:25]:
+                    lines.append(f"- {api}")
+                if len(apis_used) > 25:
+                    lines.append(f"  … and {len(apis_used) - 25} more")
+            else:
+                lines.append("(none)")
+
+            lines.append("")
+            lines.append("## Strings referenced")
+            if strings_referenced:
+                for s in strings_referenced[:25]:
+                    lines.append(f"- `{s['value']}` @ {s['address']}")
+                if len(strings_referenced) > 25:
+                    lines.append(
+                        f"  … and {len(strings_referenced) - 25} more"
+                    )
+            else:
+                lines.append("(none)")
+
+            if jump_tables:
+                lines.append("")
+                lines.append("## Jump tables")
+                for jt in jump_tables:
+                    targets = jt.get("targets") or []
+                    lines.append(
+                        f"- switch @ {jt.get('source_addr')} → "
+                        f"{len(targets)} cases"
+                    )
+
+            lines.append("")
+            lines.append("## Pseudocode rule findings")
+            if findings:
+                for hit in findings:
+                    lines.append(
+                        f"- [{hit['severity'].upper()}] {hit['rule_id']} "
+                        f"({hit['cwe']}): {hit['description']}"
+                    )
+                    lines.append(f"    excerpt: {hit['excerpt']}")
+            else:
+                lines.append("(no rule-based findings for this function)")
+
+            lines.append("")
+            lines.append("## Pseudocode")
+            if pseudo:
+                lines.append("```c")
+                lines.append(pseudo)
+                lines.append("```")
+            else:
+                lines.append(
+                    "(no pseudocode — function was likely analyzed with "
+                    "skip_decompile=True or is a thunk/external)"
+                )
+
+            return "\n".join(lines)
+
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as e:
+            return f"Invalid binary path: {e}"
+        except Exception as e:
+            logger.exception(f"get_review_package failed: {e}")
+            return f"Error: {e}"
+
+    # -- switch-tables reader (pairs with core_analysis.py extension) -------
+
+    @app.tool()
+    def get_switch_tables(
+        binary_path: str,
+        function_name_or_address: str | None = None,
+        limit: int = 200,
+    ) -> str:
+        """
+        List extracted jump / switch tables.
+
+        Reads the ``jump_tables`` field populated by ``core_analysis.py``
+        during ``analyze_binary``. Useful for dispatch-heavy binaries
+        (e.g. mpengine signal-code dispatchers).
+
+        Args:
+            binary_path: Path to analyzed binary
+            function_name_or_address: Restrict to one function; if omitted,
+                list tables across the whole binary
+            limit: Max tables to list (default 200)
+
+        Returns:
+            Formatted listing of switch_addr → N cases, or guidance if the
+            cache predates the jump_tables extraction.
+        """
+        try:
+            limit = validate_numeric_range(limit, 1, 10000, "limit")
+            context, _ = _load_context(binary_path, cache, runner)
+            functions = context.get("functions", [])
+
+            if function_name_or_address:
+                target = _find_function(functions, function_name_or_address)
+                if not target:
+                    return f"Function not found: {function_name_or_address}."
+                candidates = [target]
+            else:
+                candidates = functions
+
+            tables: list[tuple[dict, dict]] = []
+            any_has_field = False
+            for func in candidates:
+                if "jump_tables" in func:
+                    any_has_field = True
+                for jt in func.get("jump_tables") or []:
+                    tables.append((func, jt))
+
+            if not any_has_field:
+                return (
+                    "No jump_tables data in cache — this cache was produced "
+                    "by a version of core_analysis.py that predates jump-table "
+                    "extraction. Re-run `analyze_binary(path, force_reanalyze=True)`."
+                )
+
+            total = len(tables)
+            tables = tables[:limit]
+
+            if not tables:
+                return "No jump/switch tables found."
+
+            lines = [f"**Jump tables: {total} total ({len(tables)} shown)**", ""]
+            for func, jt in tables:
+                targets = jt.get("targets") or []
+                lines.append(
+                    f"- {func.get('name')} @ {func.get('address')} — "
+                    f"switch @ {jt.get('source_addr')} → {len(targets)} cases"
+                )
+                for t in targets[:12]:
+                    lines.append(f"    → {t}")
+                if len(targets) > 12:
+                    lines.append(f"    … and {len(targets) - 12} more")
+            return "\n".join(lines)
+
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as e:
+            return f"Invalid binary path: {e}"
+        except Exception as e:
+            logger.exception(f"get_switch_tables failed: {e}")
+            return f"Error: {e}"
+
+    # Keep a tuple export so the caller can introspect what was registered
+    return (
+        get_function_callers,
+        scan_pseudocode,
+        get_review_package,
+        get_switch_tables,
+    )

--- a/src/tools/windbg_tools.py
+++ b/src/tools/windbg_tools.py
@@ -312,7 +312,7 @@ def register_windbg_tools(
                 loc = bridge.get_current_location()
                 return f"Break at 0x{loc.get('address', '?')}"
             except Exception:
-                return f"Timeout after {timeout}s — target still running"
+                return f"Timeout after {timeout}s -- target still running"
         except (WinDbgBridgeError, StructuredBaseError) as e:
             return f"Error: {e}"
 
@@ -342,7 +342,7 @@ def register_windbg_tools(
                 loc = bridge.get_current_location()
                 return f"Paused at 0x{loc.get('address', '?')}"
             except Exception:
-                return f"Timeout after {timeout}s — target not paused"
+                return f"Timeout after {timeout}s -- target not paused"
         except (WinDbgBridgeError, StructuredBaseError) as e:
             return f"Error: {e}"
 

--- a/src/utils/binary_reader.py
+++ b/src/utils/binary_reader.py
@@ -60,7 +60,7 @@ class BinaryReader:
         ):
             self._open_macho()
         else:
-            # Unknown format — open file for raw reads
+            # Unknown format -- open file for raw reads
             self._format = "raw"
             self._file = open(self._path, "rb")  # noqa: SIM115
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -160,7 +160,13 @@ CONFIG_KEYS = {
 
     # Ghidra
     "GHIDRA_HOME": "Path to Ghidra installation directory",
-    "GHIDRA_TIMEOUT": "Default timeout for Ghidra analysis (seconds)",
+    "GHIDRA_TIMEOUT": "Default wall-clock timeout for Ghidra analysis (seconds, 30–3600, default 1800)",
+    "GHIDRA_FUNCTION_TIMEOUT": "Per-function decompilation timeout (seconds, default 30)",
+    "GHIDRA_MAX_FUNCTIONS": "Cap on functions processed per Ghidra run (0 = unlimited)",
+    "GHIDRA_SKIP_DECOMPILE": "Skip decompilation for fast structural pass (1/true/yes)",
+    "GHIDRA_RESUME_CACHE": "Path to a prior cache (plain or .gz) to resume analysis from",
+    "GHIDRA_START_ADDRESS": "Hex start address for chunked analysis (e.g. 0x61abbc)",
+    "GHIDRA_END_ADDRESS": "Hex end address for chunked analysis",
 
     # x64dbg
     "X64DBG_BRIDGE_URL": "URL for x64dbg HTTP bridge (default: http://localhost:27042)",

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -167,6 +167,7 @@ CONFIG_KEYS = {
     "GHIDRA_RESUME_CACHE": "Path to a prior cache (plain or .gz) to resume analysis from",
     "GHIDRA_START_ADDRESS": "Hex start address for chunked analysis (e.g. 0x61abbc)",
     "GHIDRA_END_ADDRESS": "Hex end address for chunked analysis",
+    "GHIDRA_ENABLE_FID": "Enable Function ID library matching during analysis (1/true/yes)",
 
     # x64dbg
     "X64DBG_BRIDGE_URL": "URL for x64dbg HTTP bridge (default: http://localhost:27042)",

--- a/src/utils/crypto_analysis.py
+++ b/src/utils/crypto_analysis.py
@@ -229,7 +229,7 @@ def detect_crypto_patterns(data: bytes) -> list[dict]:
     entropy_sample = data[:65536] if len(data) > 65536 else data
     entropy = calculate_entropy(entropy_sample)
 
-    # Check for Base64 (only first 64KB — Base64 payloads are in headers/resources)
+    # Check for Base64 (only first 64KB -- Base64 payloads are in headers/resources)
     b64_sample = data[:65536] if len(data) > 65536 else data
     b64_result = detect_base64(b64_sample)
     if b64_result["detected"]:
@@ -242,7 +242,7 @@ def detect_crypto_patterns(data: bytes) -> list[dict]:
             }
         })
 
-    # XOR analysis on a sample (10KB) — full-file XOR is O(n * 256) per key length
+    # XOR analysis on a sample (10KB) -- full-file XOR is O(n * 256) per key length
     xor_sample = data[:10240] if len(data) > 10240 else data
 
     # Check for single-byte XOR

--- a/src/utils/pseudocode_rules.py
+++ b/src/utils/pseudocode_rules.py
@@ -3,7 +3,7 @@ Pseudocode vulnerability rule registry.
 
 Each rule runs as a regex against Ghidra-produced pseudocode (C-like text)
 and surfaces a structured finding. Rules are deliberately conservative on
-false negatives — false positives are expected and are the point: this is
+false negatives -- false positives are expected and are the point: this is
 triage, not proof. A finding says "look here", not "this is exploitable".
 """
 
@@ -80,7 +80,7 @@ class PseudocodeRules:
                 "CWE120_SPRINTF_UNBOUNDED",
                 "CWE-120",
                 "high",
-                "sprintf/wsprintf without length cap — caller trusts format output size",
+                "sprintf/wsprintf without length cap -- caller trusts format output size",
                 "Use snprintf/_snprintf_s with an explicit destination size.",
                 r"\b(sprintf|vsprintf|wsprintf[AW]?)\s*\(",
             ),
@@ -96,7 +96,7 @@ class PseudocodeRules:
                 "CWE120_MEMCPY_SIGNED_LEN",
                 "CWE-120",
                 "medium",
-                "memcpy/memmove with a signed/int-typed length — possible negative-to-size_t wrap",
+                "memcpy/memmove with a signed/int-typed length -- possible negative-to-size_t wrap",
                 "Cast/validate length as size_t and bound-check against destination size.",
                 r"\b(memcpy|memmove|RtlCopyMemory)\s*\([^,]+,[^,]+,\s*\(?\s*(int|short|char|long)\b",
             ),
@@ -104,7 +104,7 @@ class PseudocodeRules:
                 "CWE134_FORMAT_STRING",
                 "CWE-134",
                 "high",
-                "printf-family call with a non-literal format argument — classic format-string bug",
+                "printf-family call with a non-literal format argument -- classic format-string bug",
                 "Pass a literal format string; route user data through %s arguments.",
                 r"\b(printf|fprintf|vprintf|vfprintf|syslog)\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*[,)]",
             ),
@@ -112,7 +112,7 @@ class PseudocodeRules:
                 "CWE190_MALLOC_ARITHMETIC",
                 "CWE-190",
                 "medium",
-                "Arithmetic inside malloc/calloc size argument — potential integer overflow before allocation",
+                "Arithmetic inside malloc/calloc size argument -- potential integer overflow before allocation",
                 "Validate both operands against SIZE_MAX / desired bound before multiplying.",
                 r"\b(malloc|calloc|HeapAlloc|VirtualAlloc)\s*\([^)]*[*+][^)]*\)",
             ),
@@ -120,7 +120,7 @@ class PseudocodeRules:
                 "CWE367_TOCTOU_ACCESS_OPEN",
                 "CWE-367",
                 "medium",
-                "access/stat followed by open — time-of-check to time-of-use race",
+                "access/stat followed by open -- time-of-check to time-of-use race",
                 "Open-then-check (fstat on the fd) instead of check-then-open.",
                 r"\b(access|stat|lstat)\s*\([^;]{1,200};[^;]{0,400}\b(open|fopen|CreateFile[AW]?)\s*\(",
             ),
@@ -128,7 +128,7 @@ class PseudocodeRules:
                 "CWE415_DOUBLE_FREE",
                 "CWE-415",
                 "high",
-                "Same pointer freed twice in the visible window — likely double-free",
+                "Same pointer freed twice in the visible window -- likely double-free",
                 "NULL the pointer immediately after free; add ownership discipline.",
                 r"\bfree\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)[^;]*;(?:[^;]{0,400};)?\s*free\s*\(\s*\1\s*\)",
             ),
@@ -152,7 +152,7 @@ class PseudocodeRules:
                 "CWE78_CREATEPROCESS_NONLITERAL",
                 "CWE-78",
                 "high",
-                "CreateProcess with non-literal command line — suspect if command data is attacker-influenced",
+                "CreateProcess with non-literal command line -- suspect if command data is attacker-influenced",
                 "Pass a fully-qualified application name; audit command-line construction.",
                 r"\bCreateProcess[AW]?\s*\([^)]*,[^,]*[a-zA-Z_][a-zA-Z0-9_]*\s*,",
             ),
@@ -160,7 +160,7 @@ class PseudocodeRules:
                 "CWE131_SIZEOF_TIMES_COUNT",
                 "CWE-131",
                 "low",
-                "Allocation of sizeof(T)*N — verify N is bounded (overflow check missing)",
+                "Allocation of sizeof(T)*N -- verify N is bounded (overflow check missing)",
                 "Bound-check N against SIZE_MAX/sizeof(T).",
                 r"\b(malloc|calloc|HeapAlloc)\s*\([^)]*sizeof\s*\([^)]+\)\s*\*\s*[A-Za-z_][A-Za-z0-9_]*",
             ),

--- a/src/utils/pseudocode_rules.py
+++ b/src/utils/pseudocode_rules.py
@@ -1,0 +1,246 @@
+"""
+Pseudocode vulnerability rule registry.
+
+Each rule runs as a regex against Ghidra-produced pseudocode (C-like text)
+and surfaces a structured finding. Rules are deliberately conservative on
+false negatives — false positives are expected and are the point: this is
+triage, not proof. A finding says "look here", not "this is exploitable".
+"""
+
+import re
+from dataclasses import dataclass
+
+SEVERITY_ORDER = ("info", "low", "medium", "high", "critical")
+
+
+@dataclass(frozen=True)
+class PseudocodeRule:
+    """One vulnerability / anti-pattern rule applied to decompiled C."""
+    id: str
+    cwe: str
+    severity: str
+    description: str
+    recommendation: str
+    pattern: re.Pattern
+
+
+class PseudocodeRules:
+    """Database of CWE/anti-pattern rules applied to cached pseudocode."""
+
+    def __init__(self):
+        self.rules: list[PseudocodeRule] = self._load_default_rules()
+        self._rules_by_id: dict[str, PseudocodeRule] = {r.id: r for r in self.rules}
+
+    def get(self, rule_id: str) -> PseudocodeRule | None:
+        return self._rules_by_id.get(rule_id)
+
+    def filter(
+        self,
+        severity_floor: str = "low",
+        rule_ids: list[str] | None = None,
+    ) -> list[PseudocodeRule]:
+        """Return rules at or above ``severity_floor``, optionally restricted to ``rule_ids``."""
+        try:
+            floor_idx = SEVERITY_ORDER.index(severity_floor.lower())
+        except ValueError:
+            floor_idx = SEVERITY_ORDER.index("low")
+
+        selected = []
+        for rule in self.rules:
+            try:
+                rule_idx = SEVERITY_ORDER.index(rule.severity.lower())
+            except ValueError:
+                rule_idx = SEVERITY_ORDER.index("low")
+            if rule_idx < floor_idx:
+                continue
+            if rule_ids and rule.id not in rule_ids:
+                continue
+            selected.append(rule)
+        return selected
+
+    @staticmethod
+    def _load_default_rules() -> list[PseudocodeRule]:
+        """
+        Curated rule set. Each pattern is a standalone regex.
+
+        Intentionally ordered by CWE/severity; order has no semantic meaning
+        during scanning.
+        """
+        raw: list[tuple[str, str, str, str, str, str]] = [
+            # (id, cwe, severity, description, recommendation, regex)
+            (
+                "CWE120_STRCPY",
+                "CWE-120",
+                "high",
+                "Use of strcpy/strcat without explicit length bounds",
+                "Replace with strncpy_s/strlcpy or equivalent bounded variant.",
+                r"\b(strcpy|strcat|wcscpy|wcscat|lstrcpy[AW]?|lstrcat[AW]?)\s*\(",
+            ),
+            (
+                "CWE120_SPRINTF_UNBOUNDED",
+                "CWE-120",
+                "high",
+                "sprintf/wsprintf without length cap — caller trusts format output size",
+                "Use snprintf/_snprintf_s with an explicit destination size.",
+                r"\b(sprintf|vsprintf|wsprintf[AW]?)\s*\(",
+            ),
+            (
+                "CWE120_GETS",
+                "CWE-120",
+                "critical",
+                "gets() always reads unbounded input",
+                "Replace with fgets() or getline().",
+                r"\bgets\s*\(",
+            ),
+            (
+                "CWE120_MEMCPY_SIGNED_LEN",
+                "CWE-120",
+                "medium",
+                "memcpy/memmove with a signed/int-typed length — possible negative-to-size_t wrap",
+                "Cast/validate length as size_t and bound-check against destination size.",
+                r"\b(memcpy|memmove|RtlCopyMemory)\s*\([^,]+,[^,]+,\s*\(?\s*(int|short|char|long)\b",
+            ),
+            (
+                "CWE134_FORMAT_STRING",
+                "CWE-134",
+                "high",
+                "printf-family call with a non-literal format argument — classic format-string bug",
+                "Pass a literal format string; route user data through %s arguments.",
+                r"\b(printf|fprintf|vprintf|vfprintf|syslog)\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*[,)]",
+            ),
+            (
+                "CWE190_MALLOC_ARITHMETIC",
+                "CWE-190",
+                "medium",
+                "Arithmetic inside malloc/calloc size argument — potential integer overflow before allocation",
+                "Validate both operands against SIZE_MAX / desired bound before multiplying.",
+                r"\b(malloc|calloc|HeapAlloc|VirtualAlloc)\s*\([^)]*[*+][^)]*\)",
+            ),
+            (
+                "CWE367_TOCTOU_ACCESS_OPEN",
+                "CWE-367",
+                "medium",
+                "access/stat followed by open — time-of-check to time-of-use race",
+                "Open-then-check (fstat on the fd) instead of check-then-open.",
+                r"\b(access|stat|lstat)\s*\([^;]{1,200};[^;]{0,400}\b(open|fopen|CreateFile[AW]?)\s*\(",
+            ),
+            (
+                "CWE415_DOUBLE_FREE",
+                "CWE-415",
+                "high",
+                "Same pointer freed twice in the visible window — likely double-free",
+                "NULL the pointer immediately after free; add ownership discipline.",
+                r"\bfree\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)[^;]*;(?:[^;]{0,400};)?\s*free\s*\(\s*\1\s*\)",
+            ),
+            (
+                "CWE476_NULL_DEREF_POST_MALLOC",
+                "CWE-476",
+                "medium",
+                "Pointer dereference immediately after malloc without a NULL check",
+                "Check the returned pointer against NULL before use.",
+                r"=\s*(malloc|calloc|realloc)\s*\([^;]{1,200};\s*\*",
+            ),
+            (
+                "CWE78_COMMAND_INJECTION",
+                "CWE-78",
+                "critical",
+                "system/popen/exec/ShellExecute with non-literal command argument",
+                "Use execve with argv array; never pass concatenated user data to a shell.",
+                r"\b(system|popen|WinExec|ShellExecute[AW]?|_?execl[pe]?|_?execv[pe]?)\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*[,)]",
+            ),
+            (
+                "CWE78_CREATEPROCESS_NONLITERAL",
+                "CWE-78",
+                "high",
+                "CreateProcess with non-literal command line — suspect if command data is attacker-influenced",
+                "Pass a fully-qualified application name; audit command-line construction.",
+                r"\bCreateProcess[AW]?\s*\([^)]*,[^,]*[a-zA-Z_][a-zA-Z0-9_]*\s*,",
+            ),
+            (
+                "CWE131_SIZEOF_TIMES_COUNT",
+                "CWE-131",
+                "low",
+                "Allocation of sizeof(T)*N — verify N is bounded (overflow check missing)",
+                "Bound-check N against SIZE_MAX/sizeof(T).",
+                r"\b(malloc|calloc|HeapAlloc)\s*\([^)]*sizeof\s*\([^)]+\)\s*\*\s*[A-Za-z_][A-Za-z0-9_]*",
+            ),
+            (
+                "CWE798_HARDCODED_PASSWORD",
+                "CWE-798",
+                "high",
+                "String literal resembling a password/secret hardcoded in decompilation",
+                "Load secrets from configuration/secret store, never embed in code.",
+                r'"[^"]*(pass(word)?|secret|api[_-]?key|auth[_-]?token|bearer)[^"]*"\s*',
+            ),
+            (
+                "CWE121_STACK_COPY_NO_BOUNDS",
+                "CWE-121",
+                "medium",
+                "Stack-buffer copy without visible bound check (strncpy/memcpy of stack array)",
+                "Ensure source length ≤ destination size; prefer safer wrappers.",
+                r"\b(strncpy|memcpy|RtlCopyMemory)\s*\(\s*(local_|auStack|acStack|l?u?Stack)",
+            ),
+            (
+                "CWE676_DANGEROUS_FN",
+                "CWE-676",
+                "low",
+                "Use of historically dangerous function family",
+                "Audit usage; prefer safer library equivalents where available.",
+                r"\b(scanf|sscanf|fscanf|alloca|_alloca|tmpnam|mktemp)\s*\(",
+            ),
+        ]
+
+        rules: list[PseudocodeRule] = []
+        for rid, cwe, sev, desc, rec, regex in raw:
+            rules.append(
+                PseudocodeRule(
+                    id=rid,
+                    cwe=cwe,
+                    severity=sev,
+                    description=desc,
+                    recommendation=rec,
+                    pattern=re.compile(regex, re.MULTILINE | re.DOTALL),
+                )
+            )
+        return rules
+
+
+def find_line_excerpt(pseudocode: str, match: re.Match, context_chars: int = 120) -> str:
+    """
+    Return a short single-line excerpt surrounding a match for display.
+
+    Collapses newlines/whitespace so findings fit on one line.
+    """
+    start = max(0, match.start() - context_chars // 2)
+    end = min(len(pseudocode), match.end() + context_chars // 2)
+    excerpt = pseudocode[start:end]
+    excerpt = re.sub(r"\s+", " ", excerpt).strip()
+    if start > 0:
+        excerpt = "…" + excerpt
+    if end < len(pseudocode):
+        excerpt = excerpt + "…"
+    return excerpt
+
+
+def scan_text(pseudocode: str, rules: list[PseudocodeRule]) -> list[dict]:
+    """
+    Apply a rule set to one pseudocode string, return a list of findings.
+
+    Each finding is plain dict with: rule_id, cwe, severity, description,
+    recommendation, excerpt.
+    """
+    findings: list[dict] = []
+    if not pseudocode:
+        return findings
+
+    for rule in rules:
+        for match in rule.pattern.finditer(pseudocode):
+            findings.append({
+                "rule_id": rule.id,
+                "cwe": rule.cwe,
+                "severity": rule.severity,
+                "description": rule.description,
+                "recommendation": rule.recommendation,
+                "excerpt": find_line_excerpt(pseudocode, match),
+            })
+    return findings

--- a/tests/test_control_flow_tools.py
+++ b/tests/test_control_flow_tools.py
@@ -153,6 +153,115 @@ class TestControlFlowHelpers:
         assert "401000" in index["by_addr"]
 
 
+class TestParseCapstoneArch:
+    """Language string → capstone arch tuple, covering all three parser paths."""
+
+    def _capstone_consts(self):
+        """Load capstone constants once or return None if unavailable."""
+        try:
+            from capstone import (
+                CS_ARCH_ARM,
+                CS_ARCH_ARM64,
+                CS_ARCH_X86,
+                CS_MODE_32,
+                CS_MODE_64,
+            )
+            return {
+                "X86": CS_ARCH_X86,
+                "ARM": CS_ARCH_ARM,
+                "ARM64": CS_ARCH_ARM64,
+                "M32": CS_MODE_32,
+                "M64": CS_MODE_64,
+            }
+        except ImportError:
+            return None
+
+    def test_canonical_x86_64(self):
+        """Path 1: colon-delimited canonical LanguageID."""
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({"language": "x86:LE:64:default"})
+        assert arch == c["X86"]
+        assert mode == c["M64"]
+
+    def test_canonical_x86_32(self):
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({"language": "x86:LE:32:default"})
+        assert arch == c["X86"]
+        assert mode == c["M32"]
+
+    def test_canonical_aarch64(self):
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, _ = _parse_capstone_arch({"language": "AARCH64:LE:64:v8A"})
+        assert arch == c["ARM64"]
+
+    def test_description_string_x86_64(self):
+        """Path 2: older caches stored Language.toString() description."""
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({
+            "language": "x86 / Little Endian / 64-bit pointer / default"
+        })
+        assert arch == c["X86"]
+        assert mode == c["M64"]
+
+    def test_description_split_between_fields(self):
+        """Keywords may live across language + language_description."""
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({
+            "language": "x86",
+            "language_description": "Little endian 64-bit",
+        })
+        assert arch == c["X86"]
+        assert mode == c["M64"]
+
+    def test_executable_format_fallback_pe64(self):
+        """Path 3: language unparseable but PE + 64-bit image base → x86-64."""
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({
+            "language": "",
+            "executable_format": "Portable Executable (PE)",
+            "image_base": "0x140000000",
+        })
+        assert arch == c["X86"]
+        assert mode == c["M64"]
+
+    def test_executable_format_fallback_pe32(self):
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        c = self._capstone_consts()
+        if c is None:
+            return
+        arch, mode = _parse_capstone_arch({
+            "language": "",
+            "executable_format": "Portable Executable (PE)",
+            "image_base": "0x00400000",
+        })
+        assert arch == c["X86"]
+        assert mode == c["M32"]
+
+    def test_unparseable_returns_none(self):
+        from src.tools.control_flow_tools import _parse_capstone_arch
+        arch, mode = _parse_capstone_arch({"language": ""})
+        assert arch is None
+        assert mode is None
+
+
 class TestControlFlowToolRegistration:
     """Test that tools register and handle basic inputs."""
 

--- a/tests/test_fid_tools.py
+++ b/tests/test_fid_tools.py
@@ -56,7 +56,7 @@ class TestFidMatch:
             "functions": [_func("a", "0x1000", fid_match=None)],
         })
         result = fid_match("/bin/test.exe")
-        # Field exists but nothing matched — we get the summary and guidance
+        # Field exists but nothing matched -- we get the summary and guidance
         assert "0 matched" in result
 
     def test_matched_rendered(self):
@@ -77,7 +77,7 @@ class TestFidMatch:
         result = fid_match("/bin/test.exe", filter_unmatched=True)
         assert "memcpy" in result
         assert "msvcrt_md_v142" in result
-        # Header line mentions "unmatched" in the summary — check the row body
+        # Header line mentions "unmatched" in the summary -- check the row body
         assert "`unmatched`" not in result
         assert "1 matched" in result
 

--- a/tests/test_fid_tools.py
+++ b/tests/test_fid_tools.py
@@ -1,0 +1,119 @@
+"""Tests for Function ID (FID) result-reader tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _register(cache_data):
+    from src.tools.fid_tools import register_fid_tools
+
+    app = MagicMock()
+    app.tool.return_value = lambda f: f
+    cache = MagicMock()
+    cache.get_cached.return_value = cache_data
+    runner = MagicMock()
+    session_manager = MagicMock()
+
+    (fid_match,) = register_fid_tools(app, session_manager, cache, runner)
+
+    import src.tools.fid_tools as ft
+    ft.sanitize_binary_path = lambda p, **kw: type(
+        "P", (), {"__str__": lambda self: p}
+    )()
+
+    return fid_match
+
+
+def _func(name, address, fid_match=None, include_field=True):
+    d = {
+        "name": name,
+        "address": address,
+        "is_thunk": False,
+        "is_external": False,
+    }
+    if include_field:
+        d["fid_match"] = fid_match
+    return d
+
+
+class TestFidMatch:
+    def test_no_cache(self):
+        fid_match = _register(None)
+        result = fid_match("/bin/test.exe")
+        assert "No cached analysis" in result
+        assert "enable_fid=True" in result
+
+    def test_cache_without_fid_field(self):
+        fid_match = _register({
+            "functions": [_func("a", "0x1000", include_field=False)],
+        })
+        result = fid_match("/bin/test.exe")
+        assert "no fid_match data" in result.lower()
+
+    def test_empty_matches(self):
+        fid_match = _register({
+            "functions": [_func("a", "0x1000", fid_match=None)],
+        })
+        result = fid_match("/bin/test.exe")
+        # Field exists but nothing matched — we get the summary and guidance
+        assert "0 matched" in result
+
+    def test_matched_rendered(self):
+        fid_match = _register({
+            "functions": [
+                _func(
+                    "FUN_00401000",
+                    "0x1000",
+                    fid_match={
+                        "name": "memcpy",
+                        "library": "msvcrt_md_v142",
+                        "confidence": 78.5,
+                    },
+                ),
+                _func("unmatched", "0x2000", fid_match=None),
+            ],
+        })
+        result = fid_match("/bin/test.exe", filter_unmatched=True)
+        assert "memcpy" in result
+        assert "msvcrt_md_v142" in result
+        # Header line mentions "unmatched" in the summary — check the row body
+        assert "`unmatched`" not in result
+        assert "1 matched" in result
+
+    def test_filter_unmatched_false(self):
+        fid_match = _register({
+            "functions": [
+                _func("a", "0x1000", fid_match=None),
+                _func(
+                    "b",
+                    "0x2000",
+                    fid_match={
+                        "name": "strlen",
+                        "library": "libc",
+                        "confidence": 95.0,
+                    },
+                ),
+            ],
+        })
+        result = fid_match("/bin/test.exe", filter_unmatched=False)
+        assert "no match" in result
+        assert "strlen" in result
+
+    def test_limit_applied(self):
+        fid_match = _register({
+            "functions": [
+                _func(
+                    f"f{i}",
+                    f"0x{1000 + i:x}",
+                    fid_match={
+                        "name": f"sym_{i}",
+                        "library": "libx",
+                        "confidence": 90.0,
+                    },
+                )
+                for i in range(5)
+            ],
+        })
+        result = fid_match("/bin/test.exe", limit=2)
+        assert "Showing 2 of 5" in result

--- a/tests/test_get_xrefs.py
+++ b/tests/test_get_xrefs.py
@@ -1,0 +1,180 @@
+"""
+Tests for the rewritten get_xrefs tool.
+
+Exercises the in-memory function-to-function xref derivation, string xref
+surfacing, pseudocode-mention fallback, and the explicit "no xrefs found"
+path (replacing the old "coming soon" placeholder).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub MCP deps before importing src.server. The FastMCP stub must route
+# ``@app.tool()`` through an identity decorator so the bare function is
+# callable from tests.
+sys.modules["mcp"] = MagicMock()
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.types"] = MagicMock()
+
+_identity_decorator = lambda fn: fn  # noqa: E731
+_fastmcp_instance = MagicMock()
+_fastmcp_instance.tool = MagicMock(return_value=_identity_decorator)
+_fastmcp_stub = MagicMock()
+_fastmcp_stub.FastMCP = MagicMock(return_value=_fastmcp_instance)
+sys.modules["fastmcp"] = _fastmcp_stub
+
+
+def _func(name, address, called_functions=None, pseudocode="", is_thunk=False):
+    return {
+        "name": name,
+        "address": address,
+        "called_functions": called_functions or [],
+        "pseudocode": pseudocode,
+        "is_thunk": is_thunk,
+        "is_external": False,
+        "basic_blocks": [],
+        "parameters": [],
+        "local_variables": [],
+        "signature": "",
+        "decompile_status": "success",
+        "jump_tables": [],
+        "fid_match": None,
+    }
+
+
+def _ctx(functions=None, strings=None):
+    return {
+        "metadata": {"name": "test.exe"},
+        "functions": functions or [],
+        "imports": [],
+        "strings": strings or [],
+        "memory_map": [],
+    }
+
+
+@pytest.fixture
+def server_module(tmp_path_factory, monkeypatch):
+    fake_ghidra = tmp_path_factory.mktemp("ghidra_home")
+    (fake_ghidra / "support").mkdir()
+    (fake_ghidra / "support" / "analyzeHeadless").touch()
+    monkeypatch.setenv("GHIDRA_HOME", str(fake_ghidra))
+
+    sys.modules.pop("src.server", None)
+    import src.server as server_mod
+    return server_mod
+
+
+def _wire(server_module, context, monkeypatch):
+    """Swap get_analysis_context to return our pre-baked context."""
+    monkeypatch.setattr(
+        server_module, "get_analysis_context", lambda *a, **kw: context
+    )
+
+
+class TestGetXrefsFunctionDirection:
+    def test_direction_to_surfaces_callers(self, server_module, monkeypatch):
+        target = _func("handler", "0x1000")
+        caller_a = _func(
+            "dispatch_a", "0x2000",
+            called_functions=[{"name": "handler", "address": "0x1000"}],
+        )
+        caller_b = _func(
+            "dispatch_b", "0x3000",
+            called_functions=[{"name": "handler", "address": "0x1000"}],
+        )
+        _wire(server_module, _ctx(functions=[target, caller_a, caller_b]), monkeypatch)
+
+        result = server_module.get_xrefs("/bin/test.exe", function_name="handler")
+
+        assert "dispatch_a" in result
+        assert "dispatch_b" in result
+        assert "Function calls (2)" in result
+        assert "coming soon" not in result
+
+    def test_direction_from_lists_callees(self, server_module, monkeypatch):
+        target = _func(
+            "handler", "0x1000",
+            called_functions=[
+                {"name": "strlen", "address": "0x9000"},
+                {"name": "malloc", "address": "0x9100"},
+            ],
+        )
+        _wire(server_module, _ctx(functions=[target]), monkeypatch)
+
+        result = server_module.get_xrefs(
+            "/bin/test.exe", function_name="handler", direction="from"
+        )
+        assert "strlen" in result
+        assert "malloc" in result
+        assert "Function calls (2)" in result
+
+
+class TestGetXrefsStringRefs:
+    def test_string_xrefs_inbound(self, server_module, monkeypatch):
+        # "to 0x5000" should show any function that references the string at 0x5000
+        strings = [{
+            "address": "0x5000",
+            "value": "Hello, world",
+            "xrefs": [{"from": "0x1020", "type": "READ"}],
+        }]
+        caller = _func("uses_string", "0x1000")
+        _wire(server_module, _ctx(functions=[caller], strings=strings), monkeypatch)
+
+        result = server_module.get_xrefs("/bin/test.exe", address="0x5000")
+        assert "Data / string refs" in result
+        assert "0x1020" in result
+        assert "Hello, world" in result
+
+    def test_string_xrefs_outbound(self, server_module, monkeypatch):
+        strings = [{
+            "address": "0x5000",
+            "value": "ref'd here",
+            "xrefs": [{"from": "0x1020", "type": "READ"}],
+        }]
+        _wire(server_module, _ctx(strings=strings), monkeypatch)
+
+        result = server_module.get_xrefs(
+            "/bin/test.exe", address="0x1020", direction="from"
+        )
+        assert "Data / string refs" in result
+        assert "0x5000" in result
+
+
+class TestGetXrefsEmpty:
+    def test_no_xrefs_returns_clear_message(self, server_module, monkeypatch):
+        target = _func("orphan", "0x1000")
+        _wire(server_module, _ctx(functions=[target]), monkeypatch)
+
+        result = server_module.get_xrefs("/bin/test.exe", function_name="orphan")
+
+        assert "No xrefs found" in result
+        # The old placeholder must never appear
+        assert "coming soon" not in result
+
+    def test_invalid_direction(self, server_module, monkeypatch):
+        _wire(server_module, _ctx(), monkeypatch)
+        result = server_module.get_xrefs(
+            "/bin/test.exe", address="0x1000", direction="sideways"
+        )
+        assert "Error" in result
+        assert "to" in result and "from" in result
+
+
+class TestGetXrefsPseudocodeFallback:
+    def test_pseudocode_mention_surfaced(self, server_module, monkeypatch):
+        """When no call-graph edge exists, a literal address mention in a
+        function body should still surface the caller."""
+        target = _func("target", "0x1500")
+        indirect = _func(
+            "indirect_caller", "0x2000",
+            pseudocode="fnptr = (func)0x1500; fnptr();",
+        )
+        _wire(server_module, _ctx(functions=[target, indirect]), monkeypatch)
+
+        result = server_module.get_xrefs("/bin/test.exe", function_name="target")
+        assert "Pseudocode mentions" in result
+        assert "indirect_caller" in result

--- a/tests/test_ghidra_perf.py
+++ b/tests/test_ghidra_perf.py
@@ -228,6 +228,71 @@ class TestRunnerEnvPlumbing:
         assert "GHIDRA_START_ADDRESS" not in env
         assert "GHIDRA_END_ADDRESS" not in env
         assert "GHIDRA_SKIP_DECOMPILE" not in env
+        assert "GHIDRA_ENABLE_FID" not in env
+
+    def test_enable_fid_sets_env(self, runner, tmp_path):
+        binary, script_dir, output = self._prepare(runner, tmp_path)
+        captured = {}
+
+        def fake_run(cmd, env, **kwargs):
+            captured["env"] = dict(env)
+            return _FakeRunResult()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            runner.analyze(
+                binary_path=str(binary),
+                script_path=str(script_dir),
+                script_name="core_analysis.py",
+                output_path=str(output),
+                enable_fid=True,
+            )
+
+        assert captured["env"]["GHIDRA_ENABLE_FID"] == "1"
+
+    def test_pdb_staged_adjacent_and_cleaned_up(self, runner, tmp_path):
+        """pdb_path should appear next to the binary while subprocess runs,
+        and be removed afterwards."""
+        binary, script_dir, output = self._prepare(runner, tmp_path)
+
+        pdb_src = tmp_path / "external" / "my_binary.pdb"
+        pdb_src.parent.mkdir()
+        pdb_src.write_bytes(b"PDB fake")
+
+        expected_staged = binary.parent / f"{binary.stem}.pdb"
+        saw_staged_during_run = {"ok": False}
+
+        def fake_run(cmd, env, **kwargs):
+            saw_staged_during_run["ok"] = expected_staged.exists()
+            return _FakeRunResult()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            runner.analyze(
+                binary_path=str(binary),
+                script_path=str(script_dir),
+                script_name="core_analysis.py",
+                output_path=str(output),
+                pdb_path=str(pdb_src),
+            )
+
+        assert saw_staged_during_run["ok"], "PDB wasn't staged adjacent to binary"
+        # Cleaned up after analyze returns
+        assert not expected_staged.exists()
+
+    def test_pdb_missing_file_raises(self, runner, tmp_path):
+        binary, script_dir, output = self._prepare(runner, tmp_path)
+
+        with patch("subprocess.run", return_value=_FakeRunResult()):
+            try:
+                runner.analyze(
+                    binary_path=str(binary),
+                    script_path=str(script_dir),
+                    script_name="core_analysis.py",
+                    output_path=str(output),
+                    pdb_path=str(tmp_path / "nonexistent.pdb"),
+                )
+            except FileNotFoundError:
+                return
+        raise AssertionError("Expected FileNotFoundError for missing PDB")
 
 
 # -- get_analysis_context incremental wiring --------------------------------

--- a/tests/test_ghidra_perf.py
+++ b/tests/test_ghidra_perf.py
@@ -19,9 +19,14 @@ import pytest
 sys.modules["mcp"] = MagicMock()
 sys.modules["mcp.server"] = MagicMock()
 sys.modules["mcp.types"] = MagicMock()
-# Also shim fastmcp so src.server can be imported without its real deps.
+# Shim fastmcp so src.server imports without its real deps. ``.tool()`` must
+# return an identity decorator so @app.tool-wrapped functions stay callable
+# from tests (shared with test_get_xrefs.py).
+_identity_decorator = lambda fn: fn  # noqa: E731
+_fastmcp_instance = MagicMock()
+_fastmcp_instance.tool = MagicMock(return_value=_identity_decorator)
 _fastmcp_stub = MagicMock()
-_fastmcp_stub.FastMCP = MagicMock()
+_fastmcp_stub.FastMCP = MagicMock(return_value=_fastmcp_instance)
 sys.modules["fastmcp"] = _fastmcp_stub
 
 

--- a/tests/test_ghidra_perf.py
+++ b/tests/test_ghidra_perf.py
@@ -1,0 +1,292 @@
+"""
+Tests for Ghidra large-binary performance optimisations.
+
+Covers:
+- ProjectCache gzip round-trip + legacy .json backward read.
+- Function address index side-car and get_function_by_address lookups.
+- GhidraRunner plumbing of resume/range/skip_decompile into subprocess env.
+- get_analysis_context wiring for incremental=True.
+"""
+
+import gzip
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules["mcp"] = MagicMock()
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.types"] = MagicMock()
+# Also shim fastmcp so src.server can be imported without its real deps.
+_fastmcp_stub = MagicMock()
+_fastmcp_stub.FastMCP = MagicMock()
+sys.modules["fastmcp"] = _fastmcp_stub
+
+
+# -- ProjectCache ------------------------------------------------------------
+
+class TestProjectCacheCompression:
+    def _cache(self, tmp_path):
+        from src.engines.static.ghidra.project_cache import ProjectCache
+        return ProjectCache(cache_dir=str(tmp_path))
+
+    def _make_binary(self, tmp_path, name="bin"):
+        binary = tmp_path / name
+        binary.write_bytes(b"\x7fELF" + b"\x00" * 64)
+        return binary
+
+    def test_save_writes_gzipped_json(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+
+        payload = {
+            "metadata": {"name": "bin"},
+            "functions": [{"address": "0x401000", "name": "entry"}],
+        }
+        assert cache.save_cached(str(binary), payload)
+
+        import hashlib
+        h = hashlib.sha256(binary.read_bytes()).hexdigest()
+        gz_path = tmp_path / f"{h}.json.gz"
+        assert gz_path.exists()
+
+        # Plain .json cache should NOT be written
+        assert not (tmp_path / f"{h}.json").exists()
+
+        # Round-trip
+        with gzip.open(gz_path, "rt", encoding="utf-8") as f:
+            assert json.load(f) == payload
+
+    def test_round_trip_via_api(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+        payload = {"functions": [{"address": "0x1000", "name": "f"}]}
+
+        cache.save_cached(str(binary), payload)
+        assert cache.has_cached(str(binary))
+        assert cache.get_cached(str(binary)) == payload
+
+    def test_legacy_uncompressed_json_still_readable(self, tmp_path):
+        """An older install with plain .json caches must keep working."""
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+
+        import hashlib
+        h = hashlib.sha256(binary.read_bytes()).hexdigest()
+        legacy = tmp_path / f"{h}.json"
+        legacy.write_text(json.dumps({"functions": [], "metadata": {"v": 1}}))
+
+        assert cache.has_cached(str(binary))
+        data = cache.get_cached(str(binary))
+        assert data == {"functions": [], "metadata": {"v": 1}}
+
+    def test_saving_after_legacy_read_removes_legacy_file(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+
+        import hashlib
+        h = hashlib.sha256(binary.read_bytes()).hexdigest()
+        legacy = tmp_path / f"{h}.json"
+        legacy.write_text(json.dumps({"functions": []}))
+
+        cache.save_cached(str(binary), {"functions": [{"address": "0x1", "name": "a"}]})
+
+        assert (tmp_path / f"{h}.json.gz").exists()
+        assert not legacy.exists()
+
+    def test_function_index_built_and_used(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+
+        payload = {
+            "functions": [
+                {"address": "0x1000", "name": "a"},
+                {"address": "0x2000", "name": "b"},
+                {"address": "0x3000", "name": "c"},
+            ]
+        }
+        cache.save_cached(str(binary), payload)
+
+        import hashlib
+        h = hashlib.sha256(binary.read_bytes()).hexdigest()
+        idx_path = tmp_path / f"{h}.funcidx.json"
+        assert idx_path.exists()
+        idx = json.loads(idx_path.read_text())
+        assert idx == {"0x1000": 0, "0x2000": 1, "0x3000": 2}
+
+        got = cache.get_function_by_address(str(binary), "0x2000")
+        assert got == {"address": "0x2000", "name": "b"}
+
+        assert cache.get_function_by_address(str(binary), "0xdeadbeef") is None
+
+    def test_get_cache_path_returns_gz_when_present(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+        cache.save_cached(str(binary), {"functions": []})
+
+        path = cache.get_cache_path(str(binary))
+        assert path is not None
+        assert str(path).endswith(".json.gz")
+
+    def test_invalidate_removes_all_artefacts(self, tmp_path):
+        cache = self._cache(tmp_path)
+        binary = self._make_binary(tmp_path)
+        cache.save_cached(str(binary), {"functions": [{"address": "0x1", "name": "a"}]})
+
+        assert cache.invalidate(str(binary))
+        assert not cache.has_cached(str(binary))
+
+        import hashlib
+        h = hashlib.sha256(binary.read_bytes()).hexdigest()
+        assert not (tmp_path / f"{h}.json.gz").exists()
+        assert not (tmp_path / f"{h}.funcidx.json").exists()
+        assert not (tmp_path / f"{h}.meta.json").exists()
+
+
+# -- GhidraRunner env plumbing ----------------------------------------------
+
+
+class _FakeRunResult:
+    def __init__(self):
+        self.returncode = 0
+        self.stdout = ""
+        self.stderr = ""
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch):
+    """A GhidraRunner pointed at a fake install so we can exercise analyze()."""
+    from src.engines.static.ghidra.runner import GhidraRunner
+
+    fake_ghidra = tmp_path / "ghidra"
+    (fake_ghidra / "support").mkdir(parents=True)
+    (fake_ghidra / "support" / "analyzeHeadless").touch()
+
+    return GhidraRunner(ghidra_path=str(fake_ghidra))
+
+
+class TestRunnerEnvPlumbing:
+    def _prepare(self, runner, tmp_path):
+        binary = tmp_path / "sample.bin"
+        binary.write_bytes(b"\x00" * 128)
+        script_dir = tmp_path / "scripts"
+        script_dir.mkdir()
+        output = tmp_path / "out.json"
+        return binary, script_dir, output
+
+    def test_resume_and_range_env_vars_forwarded(self, runner, tmp_path):
+        binary, script_dir, output = self._prepare(runner, tmp_path)
+        captured = {}
+
+        def fake_run(cmd, env, **kwargs):
+            captured["env"] = dict(env)
+            return _FakeRunResult()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            runner.analyze(
+                binary_path=str(binary),
+                script_path=str(script_dir),
+                script_name="core_analysis.py",
+                output_path=str(output),
+                resume_from_cache="/tmp/prior.json.gz",
+                start_address="0x61abbc",
+                end_address="0x800000",
+                skip_decompile=True,
+                max_functions=5000,
+                function_timeout=15,
+            )
+
+        env = captured["env"]
+        assert env["GHIDRA_RESUME_CACHE"] == "/tmp/prior.json.gz"
+        assert env["GHIDRA_START_ADDRESS"] == "0x61abbc"
+        assert env["GHIDRA_END_ADDRESS"] == "0x800000"
+        assert env["GHIDRA_SKIP_DECOMPILE"] == "1"
+        assert env["GHIDRA_MAX_FUNCTIONS"] == "5000"
+        assert env["GHIDRA_FUNCTION_TIMEOUT"] == "15"
+        assert env["GHIDRA_CONTEXT_JSON"] == str(output)
+
+    def test_no_resume_env_when_not_requested(self, runner, tmp_path):
+        binary, script_dir, output = self._prepare(runner, tmp_path)
+        captured = {}
+
+        def fake_run(cmd, env, **kwargs):
+            captured["env"] = dict(env)
+            return _FakeRunResult()
+
+        with patch("subprocess.run", side_effect=fake_run):
+            runner.analyze(
+                binary_path=str(binary),
+                script_path=str(script_dir),
+                script_name="core_analysis.py",
+                output_path=str(output),
+            )
+
+        env = captured["env"]
+        assert "GHIDRA_RESUME_CACHE" not in env
+        assert "GHIDRA_START_ADDRESS" not in env
+        assert "GHIDRA_END_ADDRESS" not in env
+        assert "GHIDRA_SKIP_DECOMPILE" not in env
+
+
+# -- get_analysis_context incremental wiring --------------------------------
+
+
+@pytest.fixture
+def server_module(tmp_path_factory, monkeypatch):
+    """Import src.server with a stubbed Ghidra installation."""
+    fake_ghidra = tmp_path_factory.mktemp("ghidra_home")
+    (fake_ghidra / "support").mkdir()
+    (fake_ghidra / "support" / "analyzeHeadless").touch()
+    monkeypatch.setenv("GHIDRA_HOME", str(fake_ghidra))
+
+    # Ensure a fresh import in case a prior test already loaded it
+    sys.modules.pop("src.server", None)
+    import src.server as server_mod
+    return server_mod
+
+
+class TestIncrementalWiring:
+    def test_incremental_passes_cache_path_to_runner(
+        self, tmp_path, monkeypatch, server_module
+    ):
+        """incremental=True with an existing cache should hand the path to Ghidra."""
+        from src.engines.static.ghidra.project_cache import ProjectCache
+
+        binary = tmp_path / "target.bin"
+        binary.write_bytes(b"\x7fELF" + b"\x00" * 128)
+
+        cache_obj = ProjectCache(cache_dir=str(tmp_path / "cache"))
+        cache_obj.save_cached(
+            str(binary),
+            {"functions": [{"address": "0x1000", "name": "pre"}], "metadata": {}},
+        )
+
+        monkeypatch.setattr(server_module, "cache", cache_obj)
+        monkeypatch.setattr(
+            server_module, "get_allowed_dirs", lambda: [tmp_path]
+        )
+
+        captured = {}
+
+        def fake_analyze(**kwargs):
+            captured.update(kwargs)
+            output = Path(kwargs["output_path"])
+            output.write_text(json.dumps({
+                "metadata": {"executable_format": "ELF"},
+                "functions": [{"address": "0x1000", "name": "pre"}],
+                "imports": [{"library": "libc"}],
+                "strings": [],
+                "memory_map": [{"name": ".text"}],
+                "analysis_stats": {"resumed": True, "resumed_from_count": 1},
+            }))
+            return {"elapsed_time": 1.0, "stdout": "", "stderr": ""}
+
+        monkeypatch.setattr(server_module.runner, "analyze", fake_analyze)
+
+        server_module.get_analysis_context(str(binary), incremental=True)
+
+        resume_arg = captured.get("resume_from_cache")
+        assert resume_arg is not None
+        assert resume_arg.endswith(".json.gz")

--- a/tests/test_review_tools.py
+++ b/tests/test_review_tools.py
@@ -1,0 +1,320 @@
+"""
+Tests for review / pseudocode-analysis tools.
+
+Uses the _make_function() / _make_analysis_context() factory style
+established in tests/test_control_flow_tools.py — tests call tool
+functions directly (returned by register_review_tools) with a MagicMock
+cache so no Ghidra is needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _make_function(
+    name="test_func",
+    address="0x401000",
+    basic_blocks=None,
+    called_functions=None,
+    pseudocode="int test_func() { return 0; }",
+    is_thunk=False,
+    is_external=False,
+    parameters=None,
+    local_variables=None,
+    signature="int test_func(void)",
+    decompile_status="success",
+    jump_tables=None,
+    fid_match=None,
+    name_source="ANALYSIS",
+):
+    return {
+        "name": name,
+        "address": address,
+        "basic_blocks": basic_blocks or [],
+        "called_functions": called_functions or [],
+        "pseudocode": pseudocode,
+        "is_thunk": is_thunk,
+        "is_external": is_external,
+        "parameters": parameters or [],
+        "local_variables": local_variables or [],
+        "signature": signature,
+        "decompile_status": decompile_status,
+        "jump_tables": jump_tables or [],
+        "fid_match": fid_match,
+        "name_source": name_source,
+    }
+
+
+def _make_context(functions=None, imports=None, strings=None):
+    return {
+        "metadata": {"name": "test.exe", "executable_format": "PE"},
+        "functions": functions or [],
+        "imports": imports or [],
+        "strings": strings or [],
+        "memory_map": [],
+    }
+
+
+def _register(cache_data):
+    """Register tools with a cache mock that returns the given context."""
+    from src.tools.review_tools import register_review_tools
+
+    app = MagicMock()
+    app.tool.return_value = lambda f: f
+    cache = MagicMock()
+    cache.get_cached.return_value = cache_data
+    runner = MagicMock()
+    session_manager = MagicMock()
+
+    (
+        get_function_callers,
+        scan_pseudocode,
+        get_review_package,
+        get_switch_tables,
+    ) = register_review_tools(app, session_manager, cache, runner)
+
+    # Patch sanitize so tests don't need a real file on disk
+    import src.tools.review_tools as rt
+    rt.sanitize_binary_path = lambda p, **kw: type("P", (), {"__str__": lambda self: p})()
+
+    return {
+        "get_function_callers": get_function_callers,
+        "scan_pseudocode": scan_pseudocode,
+        "get_review_package": get_review_package,
+        "get_switch_tables": get_switch_tables,
+        "cache": cache,
+        "runner": runner,
+    }
+
+
+# -- get_function_callers --------------------------------------------------
+
+
+class TestGetFunctionCallers:
+    def test_callers_inverted_correctly(self):
+        a = _make_function(name="target", address="0x1000", pseudocode="")
+        b = _make_function(
+            name="caller_b", address="0x2000", pseudocode="",
+            called_functions=[{"name": "target", "address": "0x1000"}],
+        )
+        c = _make_function(
+            name="caller_c", address="0x3000", pseudocode="",
+            called_functions=[{"name": "target", "address": "0x1000"}],
+        )
+        tools = _register(_make_context(functions=[a, b, c]))
+
+        result = tools["get_function_callers"]("/bin/test.exe", "target")
+        assert "caller_b" in result
+        assert "caller_c" in result
+        assert "Total: 2" in result
+
+    def test_unknown_function(self):
+        tools = _register(_make_context(functions=[_make_function()]))
+        result = tools["get_function_callers"]("/bin/test.exe", "missing")
+        assert "not found" in result.lower()
+
+    def test_limit_honoured(self):
+        target = _make_function(name="t", address="0x1000", pseudocode="")
+        callers = [
+            _make_function(
+                name=f"caller_{i}", address=f"0x{2000 + i:x}", pseudocode="",
+                called_functions=[{"name": "t", "address": "0x1000"}],
+            )
+            for i in range(10)
+        ]
+        tools = _register(_make_context(functions=[target] + callers))
+        result = tools["get_function_callers"]("/bin/test.exe", "t", limit=3)
+        assert "Total: 10" in result
+        assert "showing 3" in result
+
+    def test_address_lookup(self):
+        a = _make_function(name="target", address="0x1000", pseudocode="")
+        b = _make_function(
+            name="b", address="0x2000", pseudocode="",
+            called_functions=[{"name": "target", "address": "0x1000"}],
+        )
+        tools = _register(_make_context(functions=[a, b]))
+        result = tools["get_function_callers"]("/bin/test.exe", "0x1000")
+        assert "b" in result
+
+
+# -- scan_pseudocode -------------------------------------------------------
+
+
+class TestScanPseudocode:
+    def test_strcpy_flagged(self):
+        fn = _make_function(pseudocode="char buf[16]; strcpy(buf, input);")
+        tools = _register(_make_context(functions=[fn]))
+
+        result = tools["scan_pseudocode"]("/bin/test.exe")
+        assert "CWE120_STRCPY" in result
+        assert "CWE-120" in result
+
+    def test_gets_flagged_as_critical(self):
+        fn = _make_function(pseudocode="char buf[16]; gets(buf);")
+        tools = _register(_make_context(functions=[fn]))
+
+        result = tools["scan_pseudocode"]("/bin/test.exe")
+        assert "CWE120_GETS" in result
+        assert "CRITICAL" in result
+
+    def test_severity_floor_filters_low(self):
+        fn = _make_function(pseudocode='sscanf(input, "%d", &x);')
+        tools = _register(_make_context(functions=[fn]))
+
+        # sscanf is CWE676_DANGEROUS_FN at severity "low" — floor=high should drop it
+        result = tools["scan_pseudocode"]("/bin/test.exe", severity_floor="high")
+        assert "CWE676_DANGEROUS_FN" not in result
+
+    def test_no_findings_clean_code(self):
+        fn = _make_function(pseudocode="int f() { return 42; }")
+        tools = _register(_make_context(functions=[fn]))
+
+        result = tools["scan_pseudocode"]("/bin/test.exe")
+        assert "No findings" in result
+
+    def test_function_filter_regex(self):
+        hits = _make_function(name="vuln_handler", pseudocode="strcpy(a, b);")
+        misses = _make_function(
+            name="safe_handler", address="0x2000", pseudocode="strcpy(c, d);"
+        )
+        tools = _register(_make_context(functions=[hits, misses]))
+
+        result = tools["scan_pseudocode"](
+            "/bin/test.exe", function_filter="^vuln_"
+        )
+        assert "vuln_handler" in result
+        assert "safe_handler" not in result
+
+    def test_multiple_cwe_rules_fire(self):
+        """Assorted shipped rules each have a positive test case."""
+        samples = {
+            "CWE120_STRCPY": "strcpy(dst, src);",
+            "CWE120_GETS": "gets(buffer);",
+            "CWE120_SPRINTF_UNBOUNDED": "sprintf(out, fmt, x);",
+            "CWE134_FORMAT_STRING": "printf(user_fmt);",
+            "CWE78_COMMAND_INJECTION": "system(cmd_from_user);",
+            "CWE798_HARDCODED_PASSWORD": '"password=hunter2"',
+            "CWE415_DOUBLE_FREE": "free(p); free(p);",
+            "CWE190_MALLOC_ARITHMETIC": "malloc(n * m);",
+        }
+        for rule_id, snippet in samples.items():
+            fn = _make_function(pseudocode=snippet)
+            tools = _register(_make_context(functions=[fn]))
+            result = tools["scan_pseudocode"]("/bin/test.exe")
+            assert rule_id in result, (
+                f"Rule {rule_id} did not fire on snippet: {snippet}\n"
+                f"Output: {result}"
+            )
+
+
+# -- get_review_package ----------------------------------------------------
+
+
+class TestGetReviewPackage:
+    def test_bundles_expected_sections(self):
+        target = _make_function(
+            name="handler",
+            address="0x1000",
+            signature="int handler(void *ctx)",
+            pseudocode="int handler(void *ctx) { return strlen(ctx); }",
+            called_functions=[{"name": "strlen", "address": "0x9000"}],
+            basic_blocks=[{"start": "0x1000", "end": "0x1010", "num_addresses": 16}],
+        )
+        caller = _make_function(
+            name="dispatcher",
+            address="0x2000",
+            pseudocode="",
+            called_functions=[{"name": "handler", "address": "0x1000"}],
+        )
+        imports = [{"library": "msvcrt.dll", "name": "strlen", "address": None}]
+        ctx = _make_context(functions=[target, caller], imports=imports)
+        tools = _register(ctx)
+
+        result = tools["get_review_package"]("/bin/test.exe", "handler")
+
+        # Required sections
+        for section in [
+            "# Review Package",
+            "## Signature",
+            "## Metrics",
+            "## Callers",
+            "## Callees",
+            "## Imported APIs referenced in pseudocode",
+            "## Pseudocode rule findings",
+            "## Pseudocode",
+        ]:
+            assert section in result, f"Missing section: {section}"
+
+        # Caller identified
+        assert "dispatcher" in result
+        # Callee identified
+        assert "strlen" in result
+        # API usage detected
+        assert "strlen" in result
+        # Pseudocode embedded
+        assert "return strlen(ctx)" in result
+
+    def test_partial_package_no_pseudocode(self):
+        target = _make_function(
+            name="stub",
+            address="0x1000",
+            pseudocode=None,
+            basic_blocks=[{"start": "0x1000", "end": "0x1010", "num_addresses": 16}],
+        )
+        tools = _register(_make_context(functions=[target]))
+        result = tools["get_review_package"]("/bin/test.exe", "stub")
+        assert "no pseudocode" in result.lower()
+
+    def test_unknown_function(self):
+        tools = _register(_make_context(functions=[_make_function()]))
+        result = tools["get_review_package"]("/bin/test.exe", "missing")
+        assert "not found" in result.lower()
+
+
+# -- get_switch_tables -----------------------------------------------------
+
+
+class TestGetSwitchTables:
+    def test_no_field_in_cache(self):
+        """Legacy cache without jump_tables key returns guidance."""
+        legacy = _make_function()
+        del legacy["jump_tables"]
+        tools = _register(_make_context(functions=[legacy]))
+
+        result = tools["get_switch_tables"]("/bin/test.exe")
+        assert "predates" in result.lower() or "re-run" in result.lower()
+
+    def test_lists_tables(self):
+        fn = _make_function(
+            name="dispatcher",
+            address="0x1000",
+            jump_tables=[
+                {
+                    "source_addr": "0x1020",
+                    "targets": ["0x2000", "0x2010", "0x2020"],
+                }
+            ],
+        )
+        tools = _register(_make_context(functions=[fn]))
+        result = tools["get_switch_tables"]("/bin/test.exe")
+        assert "dispatcher" in result
+        assert "switch @ 0x1020" in result
+        assert "3 cases" in result
+
+    def test_filter_to_one_function(self):
+        matching = _make_function(
+            name="keep",
+            address="0x1000",
+            jump_tables=[{"source_addr": "0x1020", "targets": ["0x2000"]}],
+        )
+        other = _make_function(
+            name="skip",
+            address="0x3000",
+            jump_tables=[{"source_addr": "0x3020", "targets": ["0x4000"]}],
+        )
+        tools = _register(_make_context(functions=[matching, other]))
+        result = tools["get_switch_tables"]("/bin/test.exe", "keep")
+        assert "keep" in result
+        assert "skip" not in result

--- a/tests/test_review_tools.py
+++ b/tests/test_review_tools.py
@@ -2,7 +2,7 @@
 Tests for review / pseudocode-analysis tools.
 
 Uses the _make_function() / _make_analysis_context() factory style
-established in tests/test_control_flow_tools.py — tests call tool
+established in tests/test_control_flow_tools.py -- tests call tool
 functions directly (returned by register_review_tools) with a MagicMock
 cache so no Ghidra is needed.
 """
@@ -163,7 +163,7 @@ class TestScanPseudocode:
         fn = _make_function(pseudocode='sscanf(input, "%d", &x);')
         tools = _register(_make_context(functions=[fn]))
 
-        # sscanf is CWE676_DANGEROUS_FN at severity "low" — floor=high should drop it
+        # sscanf is CWE676_DANGEROUS_FN at severity "low" -- floor=high should drop it
         result = tools["scan_pseudocode"]("/bin/test.exe", severity_floor="high")
         assert "CWE676_DANGEROUS_FN" not in result
 

--- a/tests/test_windbg_bridge.py
+++ b/tests/test_windbg_bridge.py
@@ -235,7 +235,7 @@ class TestABCMethodsWithMockedPybag:
         assert "0x401000" not in bridge._breakpoints
 
     def test_delete_breakpoint_fallback(self, bridge):
-        """Delete a BP that wasn't tracked — falls back to command."""
+        """Delete a BP that wasn't tracked -- falls back to command."""
         result = bridge.delete_breakpoint("0x401000")
         assert result is True
         bridge._dbg.cmd.assert_called_once_with("bc 0x401000")
@@ -677,7 +677,7 @@ class TestDumpAnalysis:
 
     @patch("src.engines.dynamic.windbg.bridge.platform.system", return_value="Windows")
     def test_open_dump_cdb_only(self, mock_sys):
-        """open_dump() uses CDB subprocess — pybag OpenDumpFile is E_NOTIMPL."""
+        """open_dump() uses CDB subprocess -- pybag OpenDumpFile is E_NOTIMPL."""
         bridge = WinDbgBridge()
         bridge._cdb_path = Path("C:\\cdb.exe")
 


### PR DESCRIPTION
Large binaries (e.g. 18MB mpengine.dll with ~60K functions) previously capped at ~35% coverage because the wall-clock budget ran out during decompilation and every re-run restarted from scratch.

- core_analysis.py: resume from prior cache via GHIDRA_RESUME_CACHE; bound iteration with GHIDRA_START_ADDRESS / GHIDRA_END_ADDRESS; surface resume stats (skipped_by_resume, skipped_by_range, partial_results).
- runner.analyze: accept resume_from_cache / start_address / end_address and forward to the Jython script as env vars.
- analyze_binary + get_analysis_context: expose skip_decompile, max_functions, function_timeout, incremental, start_address, end_address; bump default GHIDRA_TIMEOUT from 600s to 1800s.
- project_cache: write gzipped .json.gz (legacy .json still readable), persist a .funcidx.json side-car, add get_function_by_address for O(1) lookups and get_cache_path for resume plumbing.
- config: document new GHIDRA_* env vars.
- tests: new test_ghidra_perf.py covering gzip round-trip, legacy read, function index, env var forwarding, and incremental cache wiring.