### PR TITLE
fix(security): audit remediation items 1-3 + unified cache root

### DIFF
--- a/src/engines/dynamic/base_error_logger.py
+++ b/src/engines/dynamic/base_error_logger.py
@@ -13,6 +13,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from src.utils.config import get_cache_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,7 +58,7 @@ class BaseErrorLogger:
     """
     Base error logger for dynamic analysis engines.
 
-    Stores errors in `~/.ghidra_mcp_cache/<error_dir_name>/` with:
+    Stores errors in `~/ghidra_mcp_cache/<engine>_errors/` with:
     - Individual JSON files per error
     - Manifest file for quick browsing
     - Statistics for error analysis
@@ -77,13 +79,13 @@ class BaseErrorLogger:
         Initialize error logger.
 
         Args:
-            error_dir: Directory for error storage
-                       (defaults to ~/.ghidra_mcp_cache/<engine>_errors/)
+            error_dir: Directory for error storage (defaults to the
+                       ``<engine>_errors/`` subdir of the shared cache root;
+                       see ``get_cache_dir``)
             max_errors: Maximum number of errors to keep (oldest removed first)
         """
         if error_dir is None:
-            cache_dir = Path.home() / ".ghidra_mcp_cache"
-            self.error_dir = cache_dir / self._error_dir_name
+            self.error_dir = get_cache_dir() / self._error_dir_name
         else:
             self.error_dir = Path(error_dir)
 

--- a/src/engines/dynamic/windbg/allowlist.py
+++ b/src/engines/dynamic/windbg/allowlist.py
@@ -19,12 +19,14 @@ Reference: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/s
 
 The validator works in two passes:
 
-  1. ``parse_compound`` splits a user-supplied string on ``;`` outside
-     quoted regions and curly-brace blocks (so ``.foreach (a {!process})
-     {!handle ${a}}`` is one entry, not two).
-  2. ``validate_command`` checks each subcommand against deny-tokens
-     (matched on first whitespace token, case-insensitive) and
-     write-primitive regexes (matched anywhere).
+  1. ``parse_compound`` splits a user-supplied string on every separator
+     WinDbg honours -- ``;`` AND raw newlines -- outside quoted regions and
+     curly-brace blocks (so ``.foreach (a {!process}) {!handle ${a}}`` is one
+     entry, not two, while ``k\n.shell`` is two, not one).
+  2. ``validate_command`` checks each subcommand against deny-tokens (matched
+     on first whitespace token, case-insensitive, including the alias-defining
+     family that WinDbg pre-expands) and write/execute-primitive regexes
+     (matched anywhere, including the ``$<`` script-file include operators).
 
 Non-write meta-commands that have a structured replacement (e.g.
 ``.sympath`` -> :func:`windbg_set_sympath`) stay denied here so callers
@@ -85,6 +87,13 @@ _DENY_FIRST_TOKEN = frozenset({
     "eb", "ed", "ew", "eq", "ep", "eu", "ea", "eza", "ezu",
     # Assembler - emits machine code into target memory
     "a",
+    # Alias definition/deletion. WinDbg expands aliases BEFORE command-name
+    # resolution, so 'aS x .shell' then 'x' would smuggle a denied command
+    # past first-token validation (audit H3). _first_token lowercases, so
+    # 'as' also covers 'aS'. 'al' (list) is denied too for a clean surface.
+    "as", "al", "ad",
+    # .cmdtree loads a command-tree definition from a file (execution vector).
+    ".cmdtree",
 })
 
 # Argument-form deny rules. Each entry is (regex, reason) and is matched
@@ -92,6 +101,16 @@ _DENY_FIRST_TOKEN = frozenset({
 # patterns where the first token alone cannot decide (e.g. ``r`` is read,
 # ``r @rip = 0x1`` is write).
 _DENY_ARGFORM: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        # Script-file include operators: $<, $><, $$<, $$><, $$>a< all run an
+        # arbitrary debugger command file from disk (audit H2). The optional
+        # '$', '>' and 'a' between the leading '$' and '<' cover every form.
+        # Anchored at the subcommand start so it never matches a legitimate
+        # pseudo-register/alias use like '@$teb' or '${x}'.
+        re.compile(r"^\s*\$\$?>?a?<", re.IGNORECASE),
+        "script-file include ($<, $$<, $$>a< ...) is forbidden; "
+        "it runs an arbitrary debugger command file",
+    ),
     (
         re.compile(r"^\s*r\s+[^\s,]+\s*=\s*\S", re.IGNORECASE),
         "register write via 'r' is forbidden; use a structured tool",
@@ -172,8 +191,15 @@ def parse_compound(command: str) -> list[str]:
         elif not in_dq and not in_sq and ch == "}":
             depth = max(0, depth - 1)
             current.append(ch)
-        elif not in_dq and not in_sq and depth == 0 and ch == ";":
-            parts.append("".join(current).strip())
+        elif not in_dq and not in_sq and depth == 0 and ch in ";\n\r":
+            # WinDbg honours BOTH ';' and raw newlines as command separators.
+            # Splitting on newlines too closes the injection where 'k\n.shell'
+            # was validated as a single 'k' subcommand (audit H1). Empty pieces
+            # (e.g. from '\r\n' or ';;') are dropped so a separator run does not
+            # manufacture an "empty subcommand" rejection.
+            piece = "".join(current).strip()
+            if piece:
+                parts.append(piece)
             current = []
         else:
             current.append(ch)

--- a/src/engines/dynamic/windbg/bridge.py
+++ b/src/engines/dynamic/windbg/bridge.py
@@ -20,6 +20,7 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+from src.utils.config import get_cache_dir
 from src.utils.structured_errors import (
     StructuredBaseError,
     create_debugger_not_connected_error,
@@ -134,7 +135,7 @@ def _setup_debug_log() -> logging.Logger:
     """Configure file logging when WINDBG_DEBUG env var is set."""
     debug_logger = logging.getLogger("windbg.trace")
     if os.environ.get("WINDBG_DEBUG"):
-        log_path = Path.home() / ".ghidra_mcp_cache" / "windbg_debug.log"
+        log_path = get_cache_dir() / "windbg_debug.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         handler = logging.FileHandler(log_path, encoding="utf-8")
         handler.setFormatter(logging.Formatter(

--- a/src/engines/dynamic/windbg/error_logger.py
+++ b/src/engines/dynamic/windbg/error_logger.py
@@ -17,7 +17,7 @@ class WinDbgErrorLogger(BaseErrorLogger):
     """
     Error logger for WinDbg operations.
 
-    Stores errors in `~/.ghidra_mcp_cache/windbg_errors/` with:
+    Stores errors in `~/ghidra_mcp_cache/windbg_errors/` with:
     - Individual JSON files per error
     - Manifest file for quick browsing
     - Statistics for error analysis

--- a/src/engines/dynamic/x64dbg/error_logger.py
+++ b/src/engines/dynamic/x64dbg/error_logger.py
@@ -17,7 +17,7 @@ class X64DbgErrorLogger(BaseErrorLogger):
     """
     Error logger for x64dbg operations.
 
-    Stores errors in `~/.ghidra_mcp_cache/x64dbg_errors/` with:
+    Stores errors in `~/ghidra_mcp_cache/x64dbg_errors/` with:
     - Individual JSON files per error
     - Manifest file for quick browsing
     - Statistics for error analysis

--- a/src/engines/dynamic/x64dbg/plugin/plugin.cpp
+++ b/src/engines/dynamic/x64dbg/plugin/plugin.cpp
@@ -5,6 +5,7 @@
 #include <cstdarg>
 #include <string>
 #include <vector>
+#include <exception>
 #include <sstream>
 #include <iomanip>
 #include <set>
@@ -2452,9 +2453,12 @@ std::string HandleFindStrings(const std::string& request) {
     bool searchAscii = ExtractIntField(request, "ascii", 1) != 0;
     bool searchUnicode = ExtractIntField(request, "unicode", 1) != 0;
 
-    // Validate
-    if (size > 10 * 1024 * 1024) {
-        return BuildJsonResponse(false, "\"error\":\"Size too large (max 10MB)\"");
+    // Validate. The lower bound is load-bearing: ExtractIntField uses sscanf
+    // %d and accepts negatives, and a negative size would convert to a huge
+    // size_t in std::vector<unsigned char> buffer(size) below, throwing
+    // std::length_error. With no exception boundary that terminates x64dbg.
+    if (size <= 0 || size > 10 * 1024 * 1024) {
+        return BuildJsonResponse(false, "\"error\":\"Invalid size (must be 1 to 10MB)\"");
     }
     if (minLength < 2) minLength = 2;
     if (minLength > 100) minLength = 100;
@@ -2560,9 +2564,11 @@ std::string HandlePatternScan(const std::string& request) {
         return BuildJsonResponse(false, "\"error\":\"Missing pattern\"");
     }
 
-    // Validate size
-    if (size > 100 * 1024 * 1024) {
-        return BuildJsonResponse(false, "\"error\":\"Size too large (max 100MB)\"");
+    // Validate size. Lower bound is load-bearing -- a negative size reaches
+    // std::vector<unsigned char> buffer(size) below and throws
+    // std::length_error, which with no exception boundary crashes x64dbg.
+    if (size <= 0 || size > 100 * 1024 * 1024) {
+        return BuildJsonResponse(false, "\"error\":\"Invalid size (must be 1 to 100MB)\"");
     }
 
     // Parse pattern - format: "90 ?? E8 ?? ?? ?? ??" or "90??E8??????"
@@ -3786,7 +3792,14 @@ static DWORD WINAPI PipeServerThread(LPVOID lpParam) {
             } else {
                 LogInfo("Request type: %d", requestType);
 
-                // Route to appropriate handler
+                // Route to appropriate handler. Wrapped in try/catch because a
+                // handler that throws -- e.g. std::length_error / std::bad_alloc
+                // from a std::vector sized by attacker-controlled input -- would
+                // otherwise unwind out of PipeServerThread and terminate the
+                // entire x64dbg process, killing the debugging session. A bad
+                // request must cost one error reply, not the whole session.
+                // (audit P2: the exception boundary the plugin lacked.)
+                try {
                 switch (requestType) {
                     // Core debugger state
                     case GET_STATE:
@@ -4049,6 +4062,13 @@ static DWORD WINAPI PipeServerThread(LPVOID lpParam) {
                         LogError("Unknown request type: %d", requestType);
                         response = BuildJsonResponse(false, "\"error\":\"Unknown request type\"");
                         break;
+                }
+                } catch (const std::exception& e) {
+                    LogError("Handler threw exception: %s", e.what());
+                    response = BuildJsonResponse(false, "\"error\":\"Internal handler error\"");
+                } catch (...) {
+                    LogError("Handler threw unknown exception");
+                    response = BuildJsonResponse(false, "\"error\":\"Internal handler error\"");
                 }
             }
 

--- a/src/engines/dynamic/x64dbg/view_errors.py
+++ b/src/engines/dynamic/x64dbg/view_errors.py
@@ -193,7 +193,7 @@ Examples:
     parser.add_argument(
         "--error-dir",
         metavar="DIR",
-        help="Custom error directory (default: ~/.ghidra_mcp_cache/x64dbg_errors/)"
+        help="Custom error directory (default: ~/ghidra_mcp_cache/x64dbg_errors/)"
     )
 
     args = parser.parse_args()

--- a/src/engines/static/ghidra/analysis_session.py
+++ b/src/engines/static/ghidra/analysis_session.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from pathlib import Path
 
+from src.utils.config import get_cache_dir
 from src.utils.security import safe_regex_compile
 
 logger = logging.getLogger(__name__)
@@ -23,10 +24,12 @@ class AnalysisSession:
         Initialize analysis session manager.
 
         Args:
-            store_dir: Directory for session storage. Defaults to ~/.ghidra_mcp_cache/sessions
+            store_dir: Directory for session storage. Defaults to the
+                ``sessions/`` subdir of the shared cache root (see
+                ``get_cache_dir``), keeping sessions beside the analysis cache.
         """
         if store_dir is None:
-            self.store_dir = Path.home() / ".ghidra_mcp_cache" / "sessions"
+            self.store_dir = get_cache_dir() / "sessions"
         else:
             self.store_dir = Path(store_dir)
 

--- a/src/engines/static/ghidra/project_cache.py
+++ b/src/engines/static/ghidra/project_cache.py
@@ -21,6 +21,8 @@ import shutil
 import time
 from pathlib import Path
 
+from src.utils.config import get_cache_dir
+
 logger = logging.getLogger(__name__)
 
 # Side-car suffixes that share the <hash>.<suffix> stem with a cache file.
@@ -36,10 +38,13 @@ class ProjectCache:
         Initialize project cache.
 
         Args:
-            cache_dir: Directory for cache storage. Defaults to ~/.ghidra_mcp_cache
+            cache_dir: Directory for cache storage. When omitted, resolves via
+                ``get_cache_dir()`` ($BINARY_CACHE_DIR, then ~/ghidra_mcp_cache)
+                -- the same root sessions and error logs use, so runner.py's
+                ghidra_projects/ subdir stays co-located with everything else.
         """
         if cache_dir is None:
-            self.cache_dir = Path.home() / ".ghidra_mcp_cache"
+            self.cache_dir = get_cache_dir()
         else:
             self.cache_dir = Path(cache_dir)
 

--- a/src/server.py
+++ b/src/server.py
@@ -2527,6 +2527,12 @@ def search_bytes(
     try:
         from src.utils.binary_reader import BinaryReader
 
+        # search_bytes was the only file-reading tool that skipped this, so it
+        # bypassed BINARY_MCP_ALLOWED_DIRS confinement and the size ceiling
+        # entirely (audit H8). Validate up front; the except handlers below
+        # already turn PathTraversalError/FileSizeError into a safe message.
+        binary_path = str(sanitize_binary_path(binary_path))
+
         max_results = validate_numeric_range(max_results, 1, 1000, "max_results")
 
         parsed = _parse_byte_pattern(pattern)

--- a/src/utils/binary_reader.py
+++ b/src/utils/binary_reader.py
@@ -246,8 +246,20 @@ class BinaryReader:
             return offset
         return None
 
-    def read_full(self) -> bytes:
-        """Read the entire binary file. Used for byte-pattern scanning."""
+    def read_full(self, max_bytes: int = 512 * 1024 * 1024) -> bytes:
+        """Read the entire binary file, up to ``max_bytes``.
+
+        Used for byte-pattern scanning. Rejects files larger than the cap
+        rather than truncating: a silent truncation would drop matches past
+        the cap and report a clean scan (audit H8). The default mirrors the
+        500 MB ceiling ``sanitize_binary_path`` already enforces upstream.
+        """
+        size = self._path.stat().st_size
+        if size > max_bytes:
+            raise ValueError(
+                f"File too large to read fully: {size} bytes (max {max_bytes}). "
+                "Narrow the scan range or raise the cap."
+            )
         with open(self._path, "rb") as f:
             return f.read()
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -134,6 +134,23 @@ def get_config(key: str, default: str | None = None) -> str | None:
     return _config_cache.get(key, default)
 
 
+def get_cache_dir() -> Path:
+    """Resolve the shared base directory for all on-disk state.
+
+    The analysis cache, Ghidra projects, saved sessions, and per-engine error
+    logs all live under this one root so they stay co-located and can be
+    inspected or cleared together -- keeping them in agreement is why every
+    module resolves the base here instead of hardcoding its own path.
+
+    Resolution order: ``$BINARY_CACHE_DIR``, then ``~/ghidra_mcp_cache``
+    (no leading dot, so the directory is visible for inspection and cleanup).
+    """
+    configured = get_config("BINARY_CACHE_DIR")
+    if configured:
+        return Path(configured)
+    return Path.home() / "ghidra_mcp_cache"
+
+
 def get_config_bool(key: str, default: bool = False) -> bool:
     """Get a boolean configuration value."""
     value = get_config(key)

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -1,11 +1,43 @@
 """Security utilities for input validation and sanitization."""
 
 import logging
+import os
 import re
 import uuid
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Sentinel distinguishing "caller did not specify allowed_dirs" (resolve the
+# configured allow-list from BINARY_MCP_ALLOWED_DIRS) from an explicit
+# allowed_dirs=None. Almost every tool entry point omits the argument, so this
+# is what lets confinement apply uniformly without touching every call site.
+_UNSET: object = object()
+
+# The "confinement disabled" warning is emitted once per process, not per call.
+_confinement_warning_emitted = False
+
+
+def _confinement_required() -> bool:
+    """True if the operator demands a configured allow-list (fail closed)."""
+    return os.environ.get(
+        "BINARY_MCP_REQUIRE_CONFINEMENT", ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _warn_confinement_disabled_once(binary_path: str) -> None:
+    """Warn (once) that binary paths are not restricted to any directory."""
+    global _confinement_warning_emitted
+    if _confinement_warning_emitted:
+        return
+    _confinement_warning_emitted = True
+    logger.warning(
+        "Path confinement is DISABLED: BINARY_MCP_ALLOWED_DIRS is not set, so "
+        "binary paths are not restricted to any directory. Set it to a "
+        "quarantine directory, or set BINARY_MCP_REQUIRE_CONFINEMENT=1 to "
+        "refuse unconfined paths. (first unconfined access: %s)",
+        binary_path,
+    )
 
 
 class SecurityError(Exception):
@@ -25,7 +57,7 @@ class FileSizeError(SecurityError):
 
 def sanitize_binary_path(
     binary_path: str,
-    allowed_dirs: list[Path] | None = None,
+    allowed_dirs: "list[Path] | None" = _UNSET,
     max_size_bytes: int = 500 * 1024 * 1024  # 500MB default
 ) -> Path:
     """
@@ -33,18 +65,46 @@ def sanitize_binary_path(
 
     Args:
         binary_path: User-supplied path to binary file
-        allowed_dirs: List of allowed base directories (None = allow any)
+        allowed_dirs: List of allowed base directories. Omit it (the default)
+            to have the configured ``BINARY_MCP_ALLOWED_DIRS`` allow-list
+            applied automatically -- this is what confines every tool entry
+            point without each one having to pass the list. Pass an explicit
+            list to override, or ``None`` to opt out of confinement for this
+            one call.
         max_size_bytes: Maximum allowed file size in bytes
 
     Returns:
         Validated absolute path
 
     Raises:
-        PathTraversalError: If path is invalid or outside allowed directories
+        PathTraversalError: If path is invalid, outside allowed directories,
+            or confinement is required but unconfigured
         FileSizeError: If file exceeds size limit
         FileNotFoundError: If file does not exist
         ValueError: If path validation fails
     """
+    # Resolve the confinement policy centrally so every caller is confined
+    # uniformly. Historically most call sites passed no allowed_dirs and thus
+    # silently skipped confinement even when the operator had set
+    # BINARY_MCP_ALLOWED_DIRS (audit H9/P4).
+    if allowed_dirs is _UNSET:
+        allowed_dirs = get_allowed_dirs()
+
+    if not allowed_dirs:
+        # Confinement is off: unconfigured, or an explicit None/empty list.
+        # Default-open is a foot-gun -- an operator may believe analysis is
+        # sandboxed to a quarantine dir when it is not (audit M13). Fail
+        # closed if demanded; otherwise warn once and proceed unrestricted.
+        if _confinement_required():
+            raise PathTraversalError(
+                "Path confinement is required "
+                "(BINARY_MCP_REQUIRE_CONFINEMENT is set) but "
+                "BINARY_MCP_ALLOWED_DIRS is not configured; refusing to open "
+                f"{binary_path}."
+            )
+        _warn_confinement_disabled_once(binary_path)
+        allowed_dirs = None  # normalise [] -> None for the checks below
+
     # Check for symlinks BEFORE resolving (prevent TOCTOU race)
     raw_path = Path(binary_path)
 

--- a/tests/test_path_confinement.py
+++ b/tests/test_path_confinement.py
@@ -1,0 +1,102 @@
+"""
+Tests for path-confinement hardening (audit item 2: H8, H9, M13, P4).
+
+Before this change, ``sanitize_binary_path`` only enforced directory
+confinement when the *caller* passed ``allowed_dirs``. Almost every tool
+entry point called it bare, so an operator who set ``BINARY_MCP_ALLOWED_DIRS``
+still got arbitrary-file reads handed to Ghidra/ILSpy (H9), and an unset
+config silently meant "allow any" with no signal (M13). The validator now
+resolves the configured allow-list itself and can fail closed, so confinement
+is applied uniformly without touching ~30 call sites.
+
+``read_full`` also read whole files into memory unbounded (H8); it now rejects
+oversized files.
+"""
+
+import pytest
+
+from src.utils.binary_reader import BinaryReader
+from src.utils.security import PathTraversalError, sanitize_binary_path
+
+# -- H9 / P4: confinement is applied even when the caller omits allowed_dirs --
+
+
+def test_confinement_applied_when_caller_omits_allowed_dirs(tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    inside_file = allowed / "sample.bin"
+    inside_file.write_bytes(b"MZ\x00\x00")
+    outside_file = outside / "secret.bin"
+    outside_file.write_bytes(b"MZ\x00\x00")
+
+    monkeypatch.setenv("BINARY_MCP_ALLOWED_DIRS", str(allowed))
+    monkeypatch.delenv("BINARY_MCP_REQUIRE_CONFINEMENT", raising=False)
+
+    # Caller passes NO allowed_dirs -- confinement must still apply.
+    assert sanitize_binary_path(str(inside_file)) == inside_file.resolve()
+    with pytest.raises(PathTraversalError):
+        sanitize_binary_path(str(outside_file))
+
+
+def test_explicit_allowed_dirs_still_enforced(tmp_path, monkeypatch):
+    """Control: an explicitly-passed allow-list keeps working unchanged."""
+    monkeypatch.delenv("BINARY_MCP_ALLOWED_DIRS", raising=False)
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside_file = tmp_path / "b.bin"
+    outside_file.write_bytes(b"MZ\x00\x00")
+    with pytest.raises(PathTraversalError):
+        sanitize_binary_path(str(outside_file), allowed_dirs=[allowed])
+
+
+# -- M13: unconfigured behaviour (default-open with a signal, or fail closed) --
+
+
+def test_unconfigured_allows_by_default(tmp_path, monkeypatch):
+    """Back-compat: with nothing configured, analysis still works."""
+    monkeypatch.delenv("BINARY_MCP_ALLOWED_DIRS", raising=False)
+    monkeypatch.delenv("BINARY_MCP_REQUIRE_CONFINEMENT", raising=False)
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"MZ\x00\x00")
+    assert sanitize_binary_path(str(f)) == f.resolve()
+
+
+def test_require_confinement_fails_closed_when_unconfigured(tmp_path, monkeypatch):
+    """Operators can demand a hard boundary: unset allow-list -> refuse."""
+    monkeypatch.delenv("BINARY_MCP_ALLOWED_DIRS", raising=False)
+    monkeypatch.setenv("BINARY_MCP_REQUIRE_CONFINEMENT", "1")
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"MZ\x00\x00")
+    with pytest.raises(PathTraversalError):
+        sanitize_binary_path(str(f))
+
+
+def test_require_confinement_allows_inside_configured_dir(tmp_path, monkeypatch):
+    """Fail-closed mode still permits files inside the configured allow-list."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    f = allowed / "a.bin"
+    f.write_bytes(b"MZ\x00\x00")
+    monkeypatch.setenv("BINARY_MCP_ALLOWED_DIRS", str(allowed))
+    monkeypatch.setenv("BINARY_MCP_REQUIRE_CONFINEMENT", "1")
+    assert sanitize_binary_path(str(f)) == f.resolve()
+
+
+# -- H8: read_full must not slurp an unbounded file into memory --
+
+
+def test_read_full_accepts_within_cap(tmp_path):
+    f = tmp_path / "small.bin"
+    f.write_bytes(b"\x00" * 1024)
+    with BinaryReader(str(f)) as reader:
+        assert reader.read_full(max_bytes=8192) == b"\x00" * 1024
+
+
+def test_read_full_rejects_oversized(tmp_path):
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"\x00" * 4096)
+    with BinaryReader(str(f)) as reader:
+        with pytest.raises(ValueError, match="too large"):
+            reader.read_full(max_bytes=1024)

--- a/tests/test_windbg_allowlist_bypasses.py
+++ b/tests/test_windbg_allowlist_bypasses.py
@@ -1,0 +1,92 @@
+"""
+Regression tests for the WinDbg allowlist bypasses (audit H1, H2, H3).
+
+The token-aware validator split subcommands only on ``;`` and blocked a set of
+dangerous first tokens. Three separator/expansion holes let a denied command
+reach cdb anyway:
+
+  H1 newline injection   -- ``k\\n.shell calc`` was validated as just ``k``,
+     because WinDbg treats a raw newline as a command separator but
+     parse_compound did not.
+  H2 script-file include -- ``$<C:\\evil.wds`` (and $><, $$<, $$><, $$>a<) runs
+     an arbitrary debugger command file from disk; none were denied.
+  H3 alias definition    -- ``aS x .shell`` / ``aS x eb`` defines an alias that
+     WinDbg expands before command-name resolution, smuggling a denied
+     primitive past the first-token check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.engines.dynamic.windbg.allowlist import parse_compound, validate_command
+
+# -- H1: a newline is a subcommand separator, validated like ';' --
+
+
+class TestNewlineInjection:
+    @pytest.mark.parametrize("sep", ["\n", "\r", "\r\n"])
+    @pytest.mark.parametrize("payload", [
+        "k{sep}.shell calc",       # denied first token after the newline
+        "r @rip{sep}eb 1000 90",   # denied write-primitive after the newline
+        "g{sep}.dvalloc 0x1000",   # RWX alloc after the newline
+    ])
+    def test_denied_command_after_newline_is_caught(self, sep, payload):
+        ok, reason = validate_command(payload.format(sep=sep))
+        assert ok is False, f"{payload!r} with {sep!r} slipped through"
+        assert reason
+
+    def test_parse_compound_splits_on_newline(self):
+        assert parse_compound("k\n.shell calc") == ["k", ".shell calc"]
+
+    def test_crlf_between_two_reads_does_not_create_empty_subcommand(self):
+        # \r\n must not yield an empty middle subcommand that gets rejected.
+        ok, reason = validate_command("k\r\nlm")
+        assert ok is True, reason
+
+    def test_multiline_all_read_still_allowed(self):
+        ok, reason = validate_command("k\nr @rip\nlm m nt")
+        assert ok is True, reason
+
+
+# -- H2: script-file include operators are denied --
+
+
+class TestScriptFileInclude:
+    @pytest.mark.parametrize("op", ["$<", "$><", "$$<", "$$><", "$$>a<"])
+    def test_script_include_denied(self, op):
+        ok, reason = validate_command(f"{op}C:\\evil.wds")
+        assert ok is False, f"{op!r} include should be denied"
+        assert reason
+
+    def test_script_include_denied_after_newline(self):
+        ok, _ = validate_command("k\n$$>a<C:\\evil.wds")
+        assert ok is False
+
+    def test_legit_pseudo_register_still_allowed(self):
+        # $ is also used for pseudo-registers/aliases; those must NOT be denied.
+        ok, reason = validate_command("dd @$teb")
+        assert ok is True, reason
+
+
+# -- H3: alias-definition family is denied --
+
+
+class TestAliasDefinition:
+    @pytest.mark.parametrize("cmd", [
+        "aS x .shell",
+        "as x .shell",
+        "aS x eb",
+        "aS /x foo bar",
+        "ad x",
+        "ad *",
+        ".cmdtree C:\\evil.txt",
+    ])
+    def test_alias_family_denied(self, cmd):
+        ok, reason = validate_command(cmd)
+        assert ok is False, f"{cmd!r} should be denied"
+        assert reason
+
+    def test_alias_definition_denied_after_newline(self):
+        ok, _ = validate_command("g\naS x .shell")
+        assert ok is False


### PR DESCRIPTION
Two audit-remediation batches plus a cache-directory cleanup, kept on one branch.

## Item 1 — x64dbg plugin crashers (H4, H5, P2, P3)
- `FIND_STRINGS` / `PATTERN_SCAN` only bounded `size` from above; `ExtractIntField` (sscanf `%d`) accepts negatives, so `size:-1` reached `std::vector<unsigned char> buffer(size)`, converted to a huge `size_t`, and threw `std::length_error`. Added the missing `size <= 0` lower bound, mirroring the five handlers that already guard it.
- The plugin had **no exception boundary anywhere**, so any such throw unwound out of `PipeServerThread` and terminated the whole x64dbg process. Wrapped the request dispatch in a top-level try/catch that converts a handler exception into an error reply. A bad request now costs one response, not the debugging session.

## Item 2 — path confinement (H8, H9, M13, P4)
- `sanitize_binary_path` now resolves the configured `BINARY_MCP_ALLOWED_DIRS` itself when the caller omits `allowed_dirs`, so all ~30 tool entry points are confined without each passing the list. A sentinel default separates "omitted" (resolve config) from an explicit `None` (opt out).
- Unconfigured is now a loud once-per-process warning instead of silent default-open; `BINARY_MCP_REQUIRE_CONFINEMENT=1` fails closed.
- `search_bytes` (the only file-reading tool that skipped validation) now validates up front; `BinaryReader.read_full` caps the read and rejects oversized files instead of slurping/truncating.

## Cache-root unification
- The analysis cache, Ghidra projects, sessions, and error logs resolved their base dirs independently; a move of `ProjectCache` to the visible `~/ghidra_mcp_cache` had split them across two roots. Introduced `config.get_cache_dir()` (`$BINARY_CACHE_DIR`, then `~/ghidra_mcp_cache`) and routed all four consumers through it. `BINARY_CACHE_DIR` now moves all state together. **Changes the default cache location** — an existing `~/.ghidra_mcp_cache` means a one-time re-analysis.

## Tests
- `tests/test_path_confinement.py` (7 tests; 4 red before the fix).
- Full suite: **993 passed, 5 skipped**, ruff clean.

## Caveat
The C++ plugin changes (Item 1) are brace-balanced and mirror existing guards, but there is no C++ harness in-tree — they are compile-verified only by the Windows release build. Worth a tag-triggered build before relying on them.