### PR TITLE
coverage: make binary-mcp the source of truth for per-binary review coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Analyze the crash dump at C:\Windows\MEMORY.DMP
 Decompile the type MyNamespace.MyClass to C#
 ```
 
-## Capabilities (245 tools)
+## Capabilities (249 tools)
 
 ### Static Analysis (Ghidra) - 35 tools
 
@@ -117,6 +117,7 @@ Comprehensive PE header, section, import, export, resource, debug, TLS, and Rich
 - **Session Management** - Persistent analysis tracking across conversations
 - **Reporting (2)** - Generate structured analysis reports
 - **YARA (2)** - Rule scanning (optional `yara-python` dependency)
+- **Review Coverage (4)** - Per-binary review denominator, reachability scope, and a deterministic unreviewed worklist. See [docs/coverage.md](docs/coverage.md)
 
 ## Supported Formats
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Analyze the crash dump at C:\Windows\MEMORY.DMP
 Decompile the type MyNamespace.MyClass to C#
 ```
 
-## Capabilities (249 tools)
+## Capabilities (250 tools)
 
 ### Static Analysis (Ghidra) - 35 tools
 
@@ -117,7 +117,7 @@ Comprehensive PE header, section, import, export, resource, debug, TLS, and Rich
 - **Session Management** - Persistent analysis tracking across conversations
 - **Reporting (2)** - Generate structured analysis reports
 - **YARA (2)** - Rule scanning (optional `yara-python` dependency)
-- **Review Coverage (4)** - Per-binary review denominator, reachability scope, and a deterministic unreviewed worklist. See [docs/coverage.md](docs/coverage.md)
+- **Review Coverage (5)** - Per-binary review denominator, reachability scope, and a deterministic unreviewed worklist. See [docs/coverage.md](docs/coverage.md)
 
 ## Supported Formats
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -18,8 +18,18 @@ unfalsifiable. With one it is arithmetic.
 | `coverage_index` | explicit (re)index; normally automatic |
 | `mark_function_reviewed` | manual mark / unmark, optional findings note |
 
-These four return **JSON**, unlike the rest of the server, because consumers
-bind to the field names and assert invariants on the counts.
+These four return a **flat JSON object**, unlike the rest of the server, because
+consumers bind to the field names and assert invariants on the counts.
+
+They return a `dict`, not a serialized string, and that is load-bearing: FastMCP
+puts a `str` return under `structuredContent.result` *as a string*, so a client
+that peels one envelope layer lands on a string and its flat-object assumption
+breaks. Returning the object keeps every transport path flat —
+`structuredContent`, `.data` and `content[0].text` all carry the same object,
+with no `result` / `data` / `coverage` wrapper.
+`tests/test_coverage_tools.py::TestWireShape` guards this.
+
+Errors use the same flat shape, carrying an `error` key.
 
 ### `get_coverage_status(binary_id=None, binary_path=None)`
 
@@ -50,12 +60,20 @@ returning bad numbers:
 - `in_scope_total <= total`, `reviewed_in_scope <= reviewed`
 - all six counts are non-negative integers
 
-`status` is `ready` | `not_indexed` | `indexing` | `stale`. On anything other
-than `ready` **all six counts are null, never zero.** Zero would read as
+`status` is `ready` | `not_indexed` | `indexing` | `stale`.
+
+On `not_indexed`, **all six counts are null, never zero.** Zero would read as
 "complete" and terminate a review loop on a binary nobody has looked at, which
-is the precise failure this store exists to prevent. Treat a non-ready status
-as "cannot conclude", never as "done". (`indexing` is reserved; indexing is
-synchronous today and never returns it.)
+is the precise failure this store exists to prevent. Treat any non-`ready`
+status as "cannot conclude", never as "done".
+
+`stale` means the analysis cache this ledger counted has been evicted. It still
+returns the last known counts — they are the best available truth and they
+satisfy every invariant above — but they are not current, so they must not
+settle a closure decision. The rule for a consumer asserting invariants:
+assert whenever `total is not None`, not only on `ready`.
+
+`indexing` is reserved; indexing is synchronous today and never returns it.
 
 There is deliberately no `reviewed_list` on this response — an 885-entry array
 on every poll saturates a model's context. Use `get_next_unreviewed`.
@@ -90,8 +108,17 @@ Seeing a function in a list is not reviewing it, and a regex sweep that marked
 is there to prevent. Over-marking is the dangerous direction; under-marking
 just means the operator re-marks.
 
-Marking is idempotent: re-decompiling does not double-count and does not
-rewrite the original timestamp or the tool that first recorded it.
+The rule, stated for the operator: **a function is marked reviewed only if its
+body — or a semantic analysis of that specific function — was returned to the
+caller.** Never merely because the server read or produced its pseudocode
+internally. So `analyze_binary` decompiles the whole binary and marks nothing;
+`decompile_function` on a structural cache runs a targeted Ghidra decompile
+internally and marks only the function you asked for, which is also the one you
+get back; `batch_decompile` marks only what it actually printed.
+
+Marking is idempotent: re-decompiling does not double-count, and `reviewed_at`
+/ `reviewed_by` record the *first* tool that marked it and are never
+overwritten.
 
 Use `mark_function_reviewed` for work done outside binary-mcp — a Ghidra GUI
 session, objdump, a debugger — and to attach a findings note.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -150,6 +150,18 @@ every function with no direct caller is treated as a root: it over-approximates
 reachability, and over-approximating is the safe direction. Under-counting
 scope shrinks the denominator and manufactures false completion.
 
+"No direct caller" is not sufficient on its own, and the first implementation
+got this wrong. Every member of a call cycle has a direct caller — itself, or
+its partner — so a cycle reached only indirectly was never promoted, the walk
+could not enter, and the entire subtree below it fell out as
+`excluded:unreachable`. That is a shrink. On the cached corpus it was dropping
+`HttppParseUtf16Sequence` and `UxDuoParseUnknownFragment` from http.sys and the
+whole chakra garbage collector — and 100% of that bucket was a false exclusion,
+not one genuine orphan across 10 binaries. After the layered walk settles the
+residual is now promoted to roots (`reachable:cycle_root`) until a fixpoint.
+`excluded:unreachable` should be empty on any real binary; a non-zero count is
+a bug signal, and `scope_description` says so explicitly.
+
 The practical consequence on driver-shaped binaries, where the only export is
 `entry`: scope leans almost entirely on the address-taken roots, so
 `in_scope_total` lands close to `total` and the only real reduction is the

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,165 @@
+# Review coverage
+
+binary-mcp is the single source of truth for the **coverage denominator** of a
+binary: how many functions it has, how many are in scope, and how many have
+actually been reviewed. Consumers mirror the counts; they never recompute a
+total from their own mark count.
+
+The problem this solves: a reviewer reads 20 functions of a 5000-function
+binary and calls it hardened. Without an external denominator that claim is
+unfalsifiable. With one it is arithmetic.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `get_coverage_status` | the six counts, plus scope provenance |
+| `get_next_unreviewed` | deterministic worklist, ascending address |
+| `coverage_index` | explicit (re)index; normally automatic |
+| `mark_function_reviewed` | manual mark / unmark, optional findings note |
+
+These four return **JSON**, unlike the rest of the server, because consumers
+bind to the field names and assert invariants on the counts.
+
+### `get_coverage_status(binary_id=None, binary_path=None)`
+
+```jsonc
+{
+  "binary_id": "5d2d84175ed6b7ee855adef804906bd78519aa3d0bd495bed91d449aa8c5a5ca",
+  "binary_path": "/…/bindflt-28000.2387.sys",
+  "module_name": "bindflt-28000.2387.sys",
+  "image_base": "0x140000000",
+  "total": 256,
+  "in_scope_total": 248,
+  "reviewed": 6,
+  "reviewed_in_scope": 6,
+  "remaining": 250,
+  "remaining_in_scope": 242,
+  "scope_description": "forward BFS over cached called_functions from …",
+  "scope_version": "fwd-bfs-v1",
+  "indexed_at": "2026-08-03T21:30:04Z",
+  "status": "ready"
+}
+```
+
+Guaranteed server-side, and enforced by a check that raises rather than
+returning bad numbers:
+
+- `remaining == total - reviewed`
+- `remaining_in_scope == in_scope_total - reviewed_in_scope`
+- `in_scope_total <= total`, `reviewed_in_scope <= reviewed`
+- all six counts are non-negative integers
+
+`status` is `ready` | `not_indexed` | `indexing` | `stale`. On anything other
+than `ready` **all six counts are null, never zero.** Zero would read as
+"complete" and terminate a review loop on a binary nobody has looked at, which
+is the precise failure this store exists to prevent. Treat a non-ready status
+as "cannot conclude", never as "done". (`indexing` is reserved; indexing is
+synchronous today and never returns it.)
+
+There is deliberately no `reviewed_list` on this response — an 885-entry array
+on every poll saturates a model's context. Use `get_next_unreviewed`.
+
+### `get_next_unreviewed(binary_id=None, count=20, scope="in_scope", binary_path=None)`
+
+Ordered by ascending numeric address. A client that crashes mid-batch and
+re-calls gets the same head of the queue, and makes forward progress once those
+are marked. `functions: []` with `remaining_after: 0` is the terminal
+condition — but only when `status == "ready"`.
+
+`scope="all"` includes thunk / library / unreachable functions. They stay
+retrievable precisely so an under-counted scope cannot hide work.
+
+## Auto-marking
+
+These tools mark a function reviewed as a side effect:
+
+- `decompile_function`
+- `batch_decompile` — only functions whose pseudocode actually came back
+- `get_review_package`
+- `get_param_sinks`
+
+They are the calls that hand the caller a function's actual body or a semantic
+per-function analysis of it.
+
+**Everything else does not mark.** In particular `get_functions`,
+`get_imports`, `get_strings`, `get_function_callers`, `get_switch_tables`,
+`analyze_function_completeness`, and the whole-binary `scan_pseudocode` sweep.
+Seeing a function in a list is not reviewing it, and a regex sweep that marked
+3000 functions would manufacture exactly the false completion the denominator
+is there to prevent. Over-marking is the dangerous direction; under-marking
+just means the operator re-marks.
+
+Marking is idempotent: re-decompiling does not double-count and does not
+rewrite the original timestamp or the tool that first recorded it.
+
+Use `mark_function_reviewed` for work done outside binary-mcp — a Ghidra GUI
+session, objdump, a debugger — and to attach a findings note.
+
+## Scope, and what it cannot see
+
+`in_scope` is real reachability, not a name heuristic: a forward BFS over the
+`called_functions` edges already materialized in the analysis cache. No Ghidra
+run is involved.
+
+Entry points, in priority order:
+
+| `scope_reason` | Source |
+|---|---|
+| `reachable:export` | PE/ELF export table, including `entry` and TLS callbacks |
+| `reachable:ioctl_dispatch` | dispatcher candidates (same predicate `find_ioctl_handlers` uses) and their switch-table targets |
+| `reachable:indirect_root` | any function with no direct caller anywhere in the binary |
+| `reachable:callee` | discovered downstream of one of the above |
+
+Exclusions are mechanical only — `excluded:thunk`, `excluded:external`,
+`excluded:thunk_or_external` (Ghidra's `decompile_status`), `excluded:fid_library`
+(a Function ID library match; requires `analyze_binary(enable_fid=True)`).
+Nothing is excluded on a name guess.
+
+**The blind spot, stated plainly.** Indirect calls — vtables, dispatch tables,
+registered callbacks — are invisible to a forward call-graph walk. That is why
+every function with no direct caller is treated as a root: it over-approximates
+reachability, and over-approximating is the safe direction. Under-counting
+scope shrinks the denominator and manufactures false completion.
+
+The practical consequence on driver-shaped binaries, where the only export is
+`entry`: scope leans almost entirely on the address-taken roots, so
+`in_scope_total` lands close to `total` and the only real reduction is the
+thunk/library set (bindflt: 248 in scope of 256, 8 thunks excluded). That is
+the honest number, not a tighter one obtained by dropping the indirect surface.
+
+`remaining_in_scope == 0` therefore means the in-scope worklist is finished,
+**not** that the binary is. Full closure still consults `remaining`.
+
+`scope_version` records the method (`fwd-bfs-v1`). It changes whenever scope
+logic changes, and a consumer should invalidate its mirror when it does.
+
+## Storage
+
+A `<sha256>.coverage.json` side-car beside the analysis cache, sharing the same
+root (`$BINARY_CACHE_DIR`, else `~/ghidra_mcp_cache`) and the same sha stem as
+`<sha>.json.gz` / `<sha>.funcidx.json` / `<sha>.notes.json`.
+
+- **Key** — lowercase sha256 hexdigest of the file bytes. The same key
+  `ProjectCache` already uses, so re-analysis of the same file on a different
+  host resumes the same coverage row. Queries by `binary_id` work even after
+  the staged file is deleted.
+- **Addresses** — canonical lowercase hex, `0x` prefix, no zero padding
+  (`0x140006d8c`). Note that the analysis cache itself stores them *bare*;
+  normalizing is this module's job.
+  These are loader virtual addresses at the image base as loaded — not file
+  offsets, not RVAs, not runtime-rebased debugger addresses. `image_base` is
+  reported so a mismatch is detectable rather than silent.
+- **Writes** — whole-file and atomic (`os.replace`). There is no lock: two
+  clients marking the same binary concurrently race read-modify-write in the
+  classic way, later write wins. That matches the surrounding cache and is
+  acceptable at one-session-per-binary usage; a lock is the fix if that changes.
+- **Lifecycle** — survives `ProjectCache.invalidate` (so `force_reanalyze` and
+  `load_pdb` do not destroy a review history; the key is a content hash, so
+  addresses cannot have shifted). Dropped by `clear_all`.
+
+Indexing happens automatically after `analyze_binary`, and on the first status
+query for a binary that was analyzed before coverage existed. The index rebuilds
+itself when the analysis cache grows (an incremental run) or when
+`scope_version` changes — **review marks, timestamps and notes are preserved
+across a rebuild.**

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -47,7 +47,7 @@ Errors use the same flat shape, carrying an `error` key.
   "remaining": 250,
   "remaining_in_scope": 242,
   "scope_description": "forward BFS over cached called_functions from …",
-  "scope_version": "fwd-bfs-v1",
+  "scope_version": "fwd-bfs-v2",
   "indexed_at": "2026-08-03T21:30:04Z",
   "status": "ready"
 }
@@ -171,8 +171,12 @@ the honest number, not a tighter one obtained by dropping the indirect surface.
 `remaining_in_scope == 0` therefore means the in-scope worklist is finished,
 **not** that the binary is. Full closure still consults `remaining`.
 
-`scope_version` records the method (`fwd-bfs-v1`). It changes whenever scope
-logic changes, and a consumer should invalidate its mirror when it does.
+`scope_version` records the method (`fwd-bfs-v2`). It changes whenever scope
+logic changes, and a consumer should invalidate its mirror when it does. It
+is also the rebuild trigger: a stored record carrying an older string is
+re-indexed on the next status query, marks preserved. `v1` is the pre-
+fixpoint walk described above, and any record still stamped with it is
+carrying that shrunken scope until it is rebuilt.
 
 ## Storage
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -17,8 +17,9 @@ unfalsifiable. With one it is arithmetic.
 | `get_next_unreviewed` | deterministic worklist, ascending address |
 | `coverage_index` | explicit (re)index; normally automatic |
 | `mark_function_reviewed` | manual mark / unmark, optional findings note |
+| `reset_coverage` | clear every mark for a binary, or drop the record entirely |
 
-These four return a **flat JSON object**, unlike the rest of the server, because
+These five return a **flat JSON object**, unlike the rest of the server, because
 consumers bind to the field names and assert invariants on the counts.
 
 They return a `dict`, not a serialized string, and that is load-bearing: FastMCP
@@ -190,3 +191,38 @@ query for a binary that was analyzed before coverage existed. The index rebuilds
 itself when the analysis cache grows (an incremental run) or when
 `scope_version` changes — **review marks, timestamps and notes are preserved
 across a rebuild.**
+
+## Resetting a contaminated denominator
+
+Marks are preserved aggressively, and auto-marking is silent. Together those
+make one accident easy: a scripted sweep, a bulk `mark_function_reviewed`, or a
+tool run against the wrong path leaves a binary recorded as reviewed that nobody
+read. That record is worse than having none — the next campaign polls it, sees
+`remaining_in_scope: 0`, and stops.
+
+`reset_coverage` is the way out. It is deliberately a tool and not a documented
+`rm`: a glob delete in the cache directory is unreviewable and takes the
+neighbouring binaries with it.
+
+| Call | Effect |
+|---|---|
+| `reset_coverage(binary_path=...)` | clears every mark; keeps the stored function list and scope exactly as built. |
+| `reset_coverage(binary_path=..., drop_index=True)` | deletes the side-car, then rebuilds it from the current analysis cache under current scope logic. |
+
+Both return `status: "ready"` with `reviewed: 0` and the denominator intact.
+**`drop_index=True` does not leave the binary unindexed** — the record is
+rebuilt on the spot, and even if it were not, the next status query re-indexes
+automatically. You only see `not_indexed` with null counts if the *analysis*
+cache is gone too, which `reset_coverage` never touches.
+
+So the difference is not "how much is deleted", it is **which scope survives**.
+The default keeps the scope as it was computed, whenever that was; the drop
+recomputes it under the current `scope_version` and the current contents of the
+analysis cache. Prefer the default: clearing marks unlearns the claim that
+functions were read while keeping the denominator you already trust. Reach for
+`drop_index=True` when the index itself is suspect — built under scope logic you
+no longer trust, or predating an incremental re-analysis that added functions.
+
+The response reports `cleared` (how many marks were removed) so the operator
+sees the size of what was undone. Resetting a binary with no record is an error,
+not a silent no-op — it usually means the wrong `binary_id`.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -46,6 +46,7 @@ Errors use the same flat shape, carrying an `error` key.
   "reviewed_in_scope": 6,
   "remaining": 250,
   "remaining_in_scope": 242,
+  "dropped_address_count": 0,
   "scope_description": "forward BFS over cached called_functions from …",
   "scope_version": "fwd-bfs-v2",
   "indexed_at": "2026-08-03T21:30:04Z",
@@ -60,6 +61,9 @@ returning bad numbers:
 - `remaining_in_scope == in_scope_total - reviewed_in_scope`
 - `in_scope_total <= total`, `reviewed_in_scope <= reviewed`
 - all six counts are non-negative integers
+- `total + dropped_address_count == source_function_count` — the only one of
+  these that compares the denominator against something it did not derive
+  itself; see [`dropped_address_count`](#dropped_address_count)
 
 `status` is `ready` | `not_indexed` | `indexing` | `stale`.
 
@@ -112,7 +116,18 @@ just means the operator re-marks.
 The rule, stated for the operator: **a function is marked reviewed only if its
 body — or a semantic analysis of that specific function — was returned to the
 caller.** Never merely because the server read or produced its pseudocode
-internally. So `analyze_binary` decompiles the whole binary and marks nothing;
+internally.
+
+"Body" means code, not merely a non-empty string. Ghidra emits bodies that are
+only a banner comment (`/* WARNING: Globals starting with '_' overlap … */`)
+when it declines to decompile, and those are still returned to the caller but do
+not mark — showing a remark about a function is not showing the function. The
+test is a brace or a statement terminator, which keeps genuine empty stubs
+marking: `void FUN_140137c58(void) { return; }` is real, reviewable code, and
+http.sys has two of them. Across the 18500 pseudocode bodies in the cached
+corpus none lack both characters, so nothing real is excluded.
+
+So `analyze_binary` decompiles the whole binary and marks nothing;
 `decompile_function` on a structural cache runs a targeted Ghidra decompile
 internally and marks only the function you asked for, which is also the one you
 get back; `batch_decompile` marks only what it actually printed.
@@ -126,9 +141,22 @@ session, objdump, a debugger — and to attach a findings note.
 
 ## Scope, and what it cannot see
 
-`in_scope` is real reachability, not a name heuristic: a forward BFS over the
-`called_functions` edges already materialized in the analysis cache. No Ghidra
-run is involved.
+Scope is computed by a forward BFS over the `called_functions` edges already
+materialized in the analysis cache. No Ghidra run is involved.
+
+**What the walk actually decides is `scope_reason`, not membership.** Because
+unreached functions are promoted to roots until the residual is empty (below),
+every function that is not *mechanically* excluded ends up in scope. The
+identity holds exactly:
+
+```
+in_scope_total == total - (thunks + externals + FID-library matches)
+```
+
+Verified on all 29 cached binaries — chakra 25026−78=24948, jscript9
+18065−73=17992, http.sys 4422−11=4411, bindflt 256−8=248. So do not read
+`in_scope_total` as "the reachable subset": it is "the not-obviously-skippable
+subset", and the call graph only explains *why* each function is there.
 
 Entry points, in priority order:
 
@@ -159,14 +187,45 @@ could not enter, and the entire subtree below it fell out as
 whole chakra garbage collector — and 100% of that bucket was a false exclusion,
 not one genuine orphan across 10 binaries. After the layered walk settles the
 residual is now promoted to roots (`reachable:cycle_root`) until a fixpoint.
-`excluded:unreachable` should be empty on any real binary; a non-zero count is
-a bug signal, and `scope_description` says so explicitly.
+Because that fixpoint drains the residual *entirely*, `excluded:unreachable` is
+now structurally unreachable rather than merely rare — the loop cannot exit
+while any non-excluded function lacks a reason. The branch that produces it is
+kept deliberately, as a tripwire: if a future change stops the residual
+draining, the failure is toward a **smaller** denominator, so it must surface in
+the counts and in `scope_description` instead of being folded in silently.
 
-The practical consequence on driver-shaped binaries, where the only export is
-`entry`: scope leans almost entirely on the address-taken roots, so
-`in_scope_total` lands close to `total` and the only real reduction is the
-thunk/library set (bindflt: 248 in scope of 256, 8 thunks excluded). That is
-the honest number, not a tighter one obtained by dropping the indirect surface.
+The practical consequence: scope leans almost entirely on the address-taken
+roots, so `in_scope_total` lands close to `total` and the only real reduction is
+the thunk/library set. This is not driver-specific — bindflt (one export)
+reports 248 of 256, and jscript9 (98 exports) reports 17992 of 18065, the same
+~0.4% reduction. That is the honest number, not a tighter one obtained by
+dropping the indirect surface.
+
+### `dropped_address_count`
+
+How many functions the analysis cache listed that are **missing from `total`**
+because `canon_addr` could not parse their address (Ghidra `EXTERNAL:` pseudo-
+addresses, anything malformed). It is `0` on every binary in the cached corpus;
+the current extractor does not emit unparseable addresses.
+
+A non-zero value means the denominator under-counts the binary by that much, and
+no completion claim should rest on it. `scope_description` carries an explicit
+warning too. If *every* address fails to parse the tool reports `not_indexed`
+with null counts rather than `ready` with six zeros — six zeros is the
+documented terminal condition, and reporting it for a binary nobody read is the
+exact failure this store exists to prevent.
+
+The count is also cross-checked: `total + dropped_address_count` must equal
+`source_function_count`, which was recorded from the analysis cache's own
+function list. A record that fails it is rebuilt. This is the one count check
+that is not a restatement of its own arithmetic — the remaining/total/reviewed
+relations are derived and asserted a few lines apart, and cannot see a `total`
+that silently lost functions.
+
+Note that a genuinely non-zero drop is deliberately **not** a rebuild trigger:
+a binary that really does carry unparseable addresses would then re-index —
+decompressing the whole analysis cache — on every status poll, forever,
+producing the identical record each time.
 
 `remaining_in_scope == 0` therefore means the in-scope worklist is finished,
 **not** that the binary is. Full closure still consults `remaining`.
@@ -204,9 +263,33 @@ root (`$BINARY_CACHE_DIR`, else `~/ghidra_mcp_cache`) and the same sha stem as
 
 Indexing happens automatically after `analyze_binary`, and on the first status
 query for a binary that was analyzed before coverage existed. The index rebuilds
-itself when the analysis cache grows (an incremental run) or when
-`scope_version` changes — **review marks, timestamps and notes are preserved
-across a rebuild.**
+itself when the analysis cache grows (an incremental run), when `scope_version`
+changes, when `schema_version` is older than the current one, or when the
+record's own numbers do not add up — **review marks, timestamps and notes are
+preserved across a rebuild.**
+
+### Versioning, and what happens to a record we cannot read
+
+Two independent version stamps:
+
+- `schema_version` — the on-disk layout. Validated on read.
+- `scope_version` — how scope was computed. Any mismatch rebuilds.
+
+| Stored value | Behaviour |
+|---|---|
+| `schema_version` older than current, ≥ the minimum readable | layout is a subset we can still parse, so the record is read and rebuilt, **marks preserved** |
+| `schema_version` newer than current, non-integer, or absent | refused. The tool reports `not_indexed` with null counts, and re-indexes from the analysis cache with everything unreviewed |
+| `scope_version` different in either direction, future included | rebuilt under current scope semantics and re-stamped with the current string |
+
+Refusing a *future* layout rather than best-effort parsing it is deliberate:
+fields this reader does not know about may be what make the counts mean what
+they say, and the per-entry coercion (`bool(entry.get("reviewed"))`) would turn
+anything unrecognized into a confident `False`. Losing marks is the safe
+direction — it asks for work to be redone rather than claiming work that was
+never done.
+
+The scope downgrade is silent by design but detectable: the consumer reads
+`scope_version` back off the payload, and it will have changed.
 
 ## Resetting a contaminated denominator
 
@@ -223,13 +306,28 @@ neighbouring binaries with it.
 | Call | Effect |
 |---|---|
 | `reset_coverage(binary_path=...)` | clears every mark; keeps the stored function list and scope exactly as built. |
-| `reset_coverage(binary_path=..., drop_index=True)` | deletes the side-car, then rebuilds it from the current analysis cache under current scope logic. |
+| `reset_coverage(binary_path=..., drop_index=True)` | deletes the side-car, then rebuilds it from the current analysis cache under current scope logic. **Refused when there is no analysis cache to rebuild from** — see below. |
 
-Both return `status: "ready"` with `reviewed: 0` and the denominator intact.
-**`drop_index=True` does not leave the binary unindexed** — the record is
-rebuilt on the spot, and even if it were not, the next status query re-indexes
-automatically. You only see `not_indexed` with null counts if the *analysis*
-cache is gone too, which `reset_coverage` never touches.
+With the analysis cache present, both return `status: "ready"` with
+`reviewed: 0` and the denominator intact. `drop_index=True` does not leave the
+binary unindexed: the record is rebuilt on the spot, and even if it were not,
+the next status query re-indexes automatically.
+
+**Without the analysis cache, `drop_index=True` is refused.** That is not a
+hypothetical state: `ProjectCache.invalidate` evicts the analysis and
+deliberately spares this side-car, which is exactly how a ledger ends up
+`stale`. A `stale` record still carries the last known counts — it is the only
+surviving account of what was reviewed — and dropping it there is
+unrecoverable. The refusal keeps it and points at the two ways forward: re-run
+`analyze_binary` to restore the rebuild source, or reset without `drop_index`
+to clear the marks while keeping the denominator.
+
+Every `reset_coverage` response carries all six count keys, null when no record
+could be read. An **omitted** key is not a null: a consumer reading
+`payload.get("total", 0)` off a response that dropped the key lands on `0`, and
+`0` reads as "complete" — the same false completion the null-not-zero rule
+exists to prevent, arrived at through the client's default instead of the
+server's value.
 
 So the difference is not "how much is deleted", it is **which scope survives**.
 The default keeps the scope as it was computed, whenever that was; the drop

--- a/src/engines/static/ghidra/coverage_store.py
+++ b/src/engines/static/ghidra/coverage_store.py
@@ -599,6 +599,50 @@ class CoverageStore:
 
     # marking
 
+    def reset_marks(self, binary_id: str) -> int:
+        """Clear every review mark, keeping the index and the scope.
+
+        The recovery path for a contaminated ledger -- a scripted sweep, a
+        verification run against the wrong file, a pass that was retracted.
+        Without it the only remedy is deleting files out of the cache
+        directory by hand, and a denominator nobody can correct is worse than
+        no denominator: the next campaign reads "fully reviewed" and stops.
+
+        Returns the number of functions whose mark or note was cleared.
+        """
+        record = self.read(binary_id)
+        if record is None:
+            return 0
+        cleared = 0
+        for entry in (record.get("functions") or {}).values():
+            if entry.get("reviewed") or entry.get("findings_note"):
+                cleared += 1
+            entry["reviewed"] = False
+            entry["reviewed_at"] = None
+            entry["reviewed_by"] = None
+            entry["findings_note"] = None
+        if cleared:
+            self.write(record)
+        return cleared
+
+    def drop(self, binary_id: str) -> bool:
+        """Delete the coverage record entirely.
+
+        The next status query re-indexes from the analysis cache with every
+        function unreviewed. Stronger than :meth:`reset_marks` because it also
+        discards the stored scope, so it is the right call when the index
+        itself is suspect rather than only the marks.
+        """
+        path = self._coverage_path(binary_id)
+        if not path.exists():
+            return False
+        try:
+            path.unlink()
+            return True
+        except OSError as exc:
+            logger.error("Could not drop coverage side-car %s: %s", path, exc)
+            return False
+
     def mark_reviewed(
         self,
         binary_id: str,

--- a/src/engines/static/ghidra/coverage_store.py
+++ b/src/engines/static/ghidra/coverage_store.py
@@ -48,7 +48,19 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump when the on-disk layout changes in a way older readers can't handle.
-SCHEMA_VERSION = 1
+#
+# v2: records carry `dropped_address_count`. A v1 record cannot distinguish
+# "no address failed to parse" from "nobody counted", and that difference is
+# the whole point of the field, so v1 records are rebuilt rather than trusted.
+SCHEMA_VERSION = 2
+
+# Oldest layout this reader can still parse well enough to salvage review marks
+# from. Anything in [MIN..SCHEMA_VERSION) is readable but stale -- rebuilt on
+# the next status query, marks preserved. Anything outside is refused: a record
+# we cannot interpret must report `not_indexed` with null counts, because
+# serving it as `ready` would put numbers of unknown provenance in front of a
+# closure decision.
+MIN_READABLE_SCHEMA_VERSION = 1
 
 # Machine-readable identifier for the reachability method behind `in_scope`.
 # Bump on ANY change to how scope is computed -- consumers invalidate their
@@ -247,6 +259,22 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
     # residual functions with no caller inside the residual -- so provenance
     # stays meaningful; a pure cycle with no source is broken at its lowest
     # address, which keeps the result deterministic for a resuming client.
+    #
+    # When no source exists, promote the WHOLE residual in ascending address
+    # order rather than one function per pass. Skipping any address the running
+    # BFS already reached makes that sequence identical to repeatedly taking
+    # min(residual) -- the same roots, the same `scope_reason` on every
+    # function -- because once a pass has no source, no later pass has one
+    # either: if x survives a pass it was called by some y in the old residual,
+    # and y cannot have been reached (the BFS follows every callee, so it would
+    # have taken x with it), so y survives too and still calls x. The loop
+    # therefore runs at most twice -- one source pass, one cycle pass -- rather
+    # than once per independent cycle, and each pass is linear in the graph.
+    #
+    # Not a micro-optimization: every fixpoint pass on the 29-binary cached
+    # corpus is a no-source pass, so the old code recomputed `residual` and
+    # `called_within` over the entire graph once per cycle (chakra: 16 passes
+    # over 25026 functions). This sits on `get_analysis_context`'s hot path.
     while True:
         residual = {
             a for a in by_addr
@@ -262,7 +290,10 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
                     called_within.add(c_addr)
         sources = sorted(residual - called_within, key=lambda x: int(x, 16))
         if not sources:
-            sources = [min(residual, key=lambda x: int(x, 16))]
+            sources = sorted(residual, key=lambda x: int(x, 16))
+        # Termination: `sources` is drawn from `residual`, which is disjoint
+        # from `reasons`, so its first element is always promoted and every
+        # pass shrinks the residual by at least one.
         for root in sources:
             if root in reasons:
                 continue
@@ -291,6 +322,14 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
             scope_reason = excluded
             excluded_count += 1
         elif reason is None:
+            # Structurally unreachable, and deliberately kept. The fixpoint
+            # above only exits once every non-excluded address has a reason, so
+            # nothing can land here -- `in_scope` is now exactly "not
+            # mechanically excluded", and the call graph supplies provenance
+            # rather than membership. This branch is the tripwire that catches
+            # a future change breaking that: it fails toward a smaller
+            # denominator, so it must stay visible in the counts and in
+            # `scope_description` rather than being silently folded in.
             in_scope = False
             scope_reason = "excluded:unreachable"
             unreached_count += 1
@@ -319,6 +358,8 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
             f"after the walk settled"
         )
     description += f"; minus {excluded_count} thunk/external/library function(s)"
+    # Only reachable if the fixpoint above stops draining the residual -- see
+    # the tripwire comment below. Zero on all 29 cached binaries.
     if unreached_count:
         description += (
             f"; {unreached_count} function(s) still unreachable from any root "
@@ -328,7 +369,10 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
     description += ". Indirect calls are invisible to a forward walk, so scope is "
     description += (
         "over-approximated on purpose: unreached functions are promoted to roots "
-        "until nothing is left, and the denominator never shrinks on a guess."
+        "until nothing is left, and the denominator never shrinks on a guess. "
+        "Because that drains the residual entirely, in_scope_total is exactly "
+        "total minus the mechanically excluded set -- the walk supplies "
+        "scope_reason, not membership."
     )
 
     return records, description
@@ -422,6 +466,33 @@ class CoverageStore:
             return None
         if not isinstance(data, dict) or "functions" not in data:
             logger.error("Malformed coverage side-car %s: no functions map", path)
+            return None
+        version = data.get("schema_version")
+        if not isinstance(version, int) or isinstance(version, bool):
+            logger.error(
+                "Coverage side-car %s has no usable schema_version (%r); refusing "
+                "to serve counts from a record of unknown provenance",
+                path,
+                version,
+            )
+            return None
+        if not MIN_READABLE_SCHEMA_VERSION <= version <= SCHEMA_VERSION:
+            # A future layout is the dangerous one: fields this reader does not
+            # know about may be what make the counts mean what they say, and
+            # `bool()`-coercing the entries it does recognize would turn an
+            # unread binary into a confidently-reported one. Refuse instead --
+            # the caller sees `not_indexed` with null counts, and rebuilds from
+            # the analysis cache with everything unreviewed. That loses marks,
+            # which is the safe direction: it asks for work to be redone rather
+            # than claiming work that was never done.
+            logger.error(
+                "Coverage side-car %s carries schema_version %d, outside the "
+                "readable range %d..%d; treating the binary as not indexed",
+                path,
+                version,
+                MIN_READABLE_SCHEMA_VERSION,
+                SCHEMA_VERSION,
+            )
             return None
         return data
 
@@ -541,6 +612,41 @@ class CoverageStore:
 
         records, description = compute_scope(context)
 
+        # Every function whose address `canon_addr` cannot parse (a Ghidra
+        # `EXTERNAL:` pseudo-address, anything malformed) is absent from
+        # `records` and therefore absent from `total`. Nothing downstream
+        # compares `total` against the source list, and both staleness probes
+        # agree with each other, so an under-counted denominator would be
+        # served as `ready` forever.
+        dropped = len(functions) - len(records)
+        if not records:
+            # Not one address survived. Reporting `ready` with six zeros here
+            # is the documented terminal condition -- a review loop would stop
+            # on a binary nobody read. `not_indexed` with null counts is the
+            # honest answer.
+            logger.error(
+                "Coverage index for %s: none of the %d function address(es) in "
+                "the analysis cache could be parsed; reporting not_indexed "
+                "rather than a denominator of zero",
+                binary_id[:12],
+                len(functions),
+            )
+            return None
+        if dropped:
+            logger.warning(
+                "Coverage index for %s: %d of %d function(s) dropped -- their "
+                "addresses did not parse, so they are missing from the "
+                "denominator",
+                binary_id[:12],
+                dropped,
+                len(functions),
+            )
+            description += (
+                f" WARNING: {dropped} of {len(functions)} function(s) in the "
+                f"analysis cache have unparseable addresses and are missing "
+                f"from this denominator; total under-counts the binary."
+            )
+
         previous = self.read(binary_id) or {}
         prior_functions = previous.get("functions") or {}
         for addr, record in records.items():
@@ -575,10 +681,40 @@ class CoverageStore:
             "scope_version": SCOPE_VERSION,
             "scope_description": description,
             "source_function_count": len(functions),
+            "dropped_address_count": dropped,
             "functions": records,
         }
         self.write(data)
         return data
+
+    @staticmethod
+    def _counts_add_up(record: dict) -> bool:
+        """Does the stored denominator account for every source function?
+
+        ``total`` (the size of the function map) plus the addresses that failed
+        to parse must equal the function count the analysis cache supplied. The
+        two sides come from different places -- one derived at index time, one
+        recorded from the source list -- so unlike the count invariants this is
+        a real cross-check rather than a restatement of its own arithmetic.
+
+        Returns True when either field is missing: a legacy record has no
+        opinion to check, and the schema-version trigger already rebuilds it.
+        """
+        dropped = record.get("dropped_address_count")
+        source_count = record.get("source_function_count")
+        if not isinstance(dropped, int) or not isinstance(source_count, int):
+            return True
+        return len(record.get("functions") or {}) + dropped == source_count
+
+    def has_analysis_cache(self, binary_id: str) -> bool:
+        """Is the Ghidra analysis this ledger counts still on disk?
+
+        The rebuild source. Without it a dropped record cannot be reconstructed,
+        so callers that are about to destroy a record must check first.
+        """
+        return (self.cache_dir / f"{binary_id}.json.gz").exists() or (
+            self.cache_dir / f"{binary_id}.json"
+        ).exists()
 
     def ensure_indexed(
         self,
@@ -593,8 +729,9 @@ class CoverageStore:
         - No coverage record but an analysis cache exists -> index now. It is a
           pure cache walk, and reporting ``not_indexed`` for a binary that is
           already fully analyzed would strand every previously-cached target.
-        - Coverage record whose ``source_function_count`` or ``scope_version``
-          no longer matches -> re-index, preserving review marks.
+        - Coverage record whose ``source_function_count``, ``scope_version`` or
+          ``schema_version`` no longer matches, or whose own stored numbers do
+          not add up -> re-index, preserving review marks.
         - Coverage record with no analysis cache behind it any more -> ``stale``;
           the counts are still returned because they are the last known truth,
           but the consumer is told not to trust them as current.
@@ -606,10 +743,7 @@ class CoverageStore:
                 return None, STATUS_NOT_INDEXED
             return rebuilt, STATUS_READY
 
-        cache_present = (self.cache_dir / f"{binary_id}.json.gz").exists() or (
-            self.cache_dir / f"{binary_id}.json"
-        ).exists()
-        if not cache_present:
+        if not self.has_analysis_cache(binary_id):
             # The analysis this ledger counted has been evicted. Return the
             # last known counts -- they are still the best available truth --
             # but flag them as not current so nobody concludes on them.
@@ -622,7 +756,25 @@ class CoverageStore:
             and record.get("source_function_count") is not None
             and source_count != record.get("source_function_count")
         )
-        if stale_scope or stale_count:
+        # A record written before drop accounting existed cannot say whether
+        # its `total` covers every function or quietly lost some, so rebuild
+        # rather than trust it. Deliberately keyed on the schema version and on
+        # the record's own arithmetic, NOT on `dropped_address_count != 0`: a
+        # binary that genuinely has unparseable addresses would then re-index
+        # -- decompressing the whole analysis cache -- on every status poll,
+        # forever, and produce the identical record each time.
+        stale_schema = record.get("schema_version") != SCHEMA_VERSION
+        inconsistent = not self._counts_add_up(record)
+        if stale_scope or stale_count or stale_schema or inconsistent:
+            if inconsistent:
+                logger.warning(
+                    "Coverage record for %s does not add up (total=%s + dropped=%s "
+                    "!= source_function_count=%s); rebuilding",
+                    binary_id[:12],
+                    len(record.get("functions") or {}),
+                    record.get("dropped_address_count"),
+                    record.get("source_function_count"),
+                )
             rebuilt = self.index(binary_id, binary_path or record.get("binary_path"))
             if rebuilt is not None:
                 return rebuilt, STATUS_READY
@@ -658,7 +810,7 @@ class CoverageStore:
             "remaining": total - reviewed,
             "remaining_in_scope": in_scope_total - reviewed_in_scope,
         }
-        _assert_invariants(counts)
+        _assert_invariants(counts, record)
         return counts
 
     # marking
@@ -755,6 +907,27 @@ class CoverageStore:
         return {"marked": marked, "already": already, "unknown": unknown}
 
 
+def has_reviewable_body(pseudocode: object) -> bool:
+    """Did the decompiler actually return code, as opposed to a remark about it?
+
+    The auto-marking tools use this to decide whether what they handed back
+    counts as a review. Non-empty is not enough: Ghidra emits bodies that are
+    only a banner comment (``/* WARNING: Globals starting with '_' overlap */``)
+    when it declines to decompile, and marking on those advances the
+    denominator for a function whose code nobody saw.
+
+    A statement terminator or a brace is the cheapest signal that separates the
+    two. Genuine empty stubs still mark -- ``void FUN_140137c58(void) { return; }``
+    is real, reviewable code and http.sys has two of them. Across the 18500
+    pseudocode bodies in the cached corpus, none lack both characters, so this
+    rejects the comment-only case without excluding anything real.
+    """
+    if not isinstance(pseudocode, str):
+        return False
+    body = pseudocode.strip()
+    return bool(body) and ("{" in body or ";" in body)
+
+
 def auto_mark(
     cache,
     binary_path: str | None,
@@ -786,11 +959,19 @@ def auto_mark(
         logger.warning("auto-mark (%s) failed for %s: %s", tool, binary_path, exc)
 
 
-def _assert_invariants(counts: dict[str, int]) -> None:
+def _assert_invariants(counts: dict[str, int], record: dict | None = None) -> None:
     """Fail loudly on an inconsistent count set.
 
     The consumer treats an invariant violation as a hard error; producing one
     server-side would be worse than crashing, so this raises rather than logs.
+
+    The count relations below are near-tautological when :meth:`CoverageStore.counts`
+    is the caller -- it derives ``remaining`` as ``total - reviewed`` a few lines
+    before this asserts they are equal. ``record`` is what gives the check
+    something it did not compute itself: ``source_function_count`` was recorded
+    from the analysis cache's own function list, so comparing the denominator
+    against it catches the one failure the relations cannot see -- a ``total``
+    that silently lost functions.
     """
     for key, value in counts.items():
         if not isinstance(value, int) or value < 0:
@@ -805,3 +986,11 @@ def _assert_invariants(counts: dict[str, int]) -> None:
         raise CoverageError("invariant violated: in_scope_total > total")
     if counts["reviewed_in_scope"] > counts["reviewed"]:
         raise CoverageError("invariant violated: reviewed_in_scope > reviewed")
+    if record is not None and not CoverageStore._counts_add_up(record):
+        raise CoverageError(
+            "invariant violated: total + dropped_address_count != "
+            f"source_function_count (total={counts['total']}, "
+            f"dropped={record.get('dropped_address_count')!r}, "
+            f"source={record.get('source_function_count')!r}) -- the "
+            "denominator does not account for every function in the binary"
+        )

--- a/src/engines/static/ghidra/coverage_store.py
+++ b/src/engines/static/ghidra/coverage_store.py
@@ -52,8 +52,16 @@ SCHEMA_VERSION = 1
 
 # Machine-readable identifier for the reachability method behind `in_scope`.
 # Bump on ANY change to how scope is computed -- consumers invalidate their
-# mirror when this string changes.
-SCOPE_VERSION = "fwd-bfs-v1"
+# mirror when this string changes, and `_ensure_current` rebuilds any record
+# still carrying an older one.
+#
+# v2: cycle members are promoted to roots to a fixpoint. v1 treated "no direct
+# caller anywhere" as the only indirect-root signal, so a call cycle reached
+# only indirectly was never entered and its entire subtree fell out as
+# `excluded:unreachable` -- a shrunken denominator. Leaving the string at v1
+# would strand every record built before the fix, because this string IS the
+# rebuild trigger.
+SCOPE_VERSION = "fwd-bfs-v2"
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 

--- a/src/engines/static/ghidra/coverage_store.py
+++ b/src/engines/static/ghidra/coverage_store.py
@@ -1,0 +1,699 @@
+"""
+Per-binary review-coverage store.
+
+binary-mcp is the single source of truth for the coverage *denominator*: how
+many functions a binary has, how many of those are in scope, and how many have
+actually been reviewed. Consumers (vr-lab's notes-mcp ledger) mirror the counts
+and keep their own campaign semantics (stratum, verdict, finding linkage) on
+top; they never recompute a total from their own mark count.
+
+Storage
+-------
+A ``<sha256>.coverage.json`` side-car beside the existing Ghidra cache, sharing
+the same root (``$BINARY_CACHE_DIR`` / ``~/ghidra_mcp_cache``) and the same sha
+stem as ``<sha>.json.gz`` / ``<sha>.funcidx.json`` / ``<sha>.notes.json``. This
+inherits the cache's eviction and ``clean_cache`` story for free, and needs no
+new dependency. Writes are whole-file and atomic (``os.replace``).
+
+Like the notes side-car, coverage survives :meth:`ProjectCache.invalidate` --
+re-running Ghidra on the *same bytes* must not destroy a review history, and
+because the key is a content hash the addresses cannot shift underneath it.
+``clear_all`` still wipes it.
+
+Identity
+--------
+- binary: lowercase sha256 hexdigest of the file bytes, 64 chars, no prefix --
+  exactly what ``ProjectCache._get_binary_hash`` already computes.
+- function: canonical lowercase hex with a ``0x`` prefix and no zero padding
+  (``0x140006d8c``). The Ghidra cache stores bare, unprefixed hex
+  (``140006d8c``); every address crossing this module's boundary is normalized
+  through :func:`canon_addr`.
+
+Addresses are Ghidra/loader virtual addresses at the image base as loaded --
+not file offsets, not RVAs, not runtime-rebased debugger addresses. The image
+base is reported in the status payload so a mismatch is detectable rather than
+silent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Bump when the on-disk layout changes in a way older readers can't handle.
+SCHEMA_VERSION = 1
+
+# Machine-readable identifier for the reachability method behind `in_scope`.
+# Bump on ANY change to how scope is computed -- consumers invalidate their
+# mirror when this string changes.
+SCOPE_VERSION = "fwd-bfs-v1"
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Cached `decompile_status` value meaning Ghidra deliberately did not
+# decompile: a thunk or an external stub. notes-mcp already treats this as a
+# skip signal, so scope must agree with it.
+_SKIPPED_STATUS = "skipped_thunk_or_external"
+
+STATUS_READY = "ready"
+STATUS_NOT_INDEXED = "not_indexed"
+STATUS_INDEXING = "indexing"  # reserved: indexing is synchronous today
+STATUS_STALE = "stale"
+
+
+class CoverageError(RuntimeError):
+    """Raised when a coverage invariant is violated -- never swallow this."""
+
+
+# Address normalization
+
+
+def canon_addr(raw: object) -> str:
+    """Return the canonical ``0x`` + lowercase-hex form, or ``""``.
+
+    Accepts an int, a bare hex string (``"140006d8c"``), or a prefixed one
+    (``"0x140006D8C"``). Ghidra's ``EXTERNAL:0000005b`` pseudo-addresses and
+    anything unparseable return ``""`` so callers can drop them.
+
+    The output survives notes-mcp's ``_normalize_addr`` unchanged, so a naive
+    string compare matches on either side of the boundary.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, int):
+        return f"0x{raw:x}"
+    text = str(raw).strip().lower()
+    if not text or ":" in text:
+        return ""
+    if text.startswith("0x"):
+        text = text[2:]
+    try:
+        return f"0x{int(text, 16):x}"
+    except ValueError:
+        return ""
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# Scope computation
+
+
+def _collect_entry_points(context: dict, by_addr: dict[str, dict]) -> dict[str, str]:
+    """Return ``{canonical_address: scope_reason}`` for evidenced entry points.
+
+    Three sources, in priority order (an address keeps the first reason that
+    claims it):
+
+    1. ``reachable:export`` -- PE/ELF export table entries, including the
+       driver ``entry`` stub and TLS callbacks.
+    2. ``reachable:ioctl_dispatch`` -- IOCTL / opcode dispatcher candidates,
+       detected with the same predicate ``find_ioctl_handlers`` uses, plus the
+       switch-table targets those dispatchers route to.
+    3. ``reachable:indirect_root`` -- every function with no direct caller
+       anywhere in the binary. These are the registered callbacks, vtable
+       members and dispatch-table slots that a forward call-graph walk cannot
+       see. Treating them as roots OVER-approximates reachability, which is
+       the safe direction: under-counting scope shrinks the denominator and
+       manufactures false completion.
+    """
+    entries: dict[str, str] = {}
+
+    for export in context.get("exports") or []:
+        addr = canon_addr(export.get("address"))
+        if addr and addr in by_addr:
+            entries.setdefault(addr, "reachable:export")
+
+    try:
+        from src.tools.dispatch_tools import _is_dispatcher_candidate
+    except ImportError:  # pragma: no cover - defensive
+        _is_dispatcher_candidate = None
+
+    if _is_dispatcher_candidate is not None:
+        # Switch-table targets are keyed by the jump-table source address; a
+        # dispatcher's own jump_tables entry carries the target list directly.
+        for func in context.get("functions") or []:
+            try:
+                is_candidate, _hint = _is_dispatcher_candidate(func)
+            except Exception:  # pragma: no cover - never let scope break on this
+                continue
+            if not is_candidate:
+                continue
+            addr = canon_addr(func.get("address"))
+            if addr and addr in by_addr:
+                entries.setdefault(addr, "reachable:ioctl_dispatch")
+            for table in func.get("jump_tables") or []:
+                for target in table.get("targets") or []:
+                    t_addr = canon_addr(target)
+                    if t_addr and t_addr in by_addr:
+                        entries.setdefault(t_addr, "reachable:ioctl_dispatch")
+
+    called: set[str] = set()
+    for func in context.get("functions") or []:
+        for callee in func.get("called_functions") or []:
+            addr = canon_addr(callee.get("address"))
+            if addr:
+                called.add(addr)
+
+    for addr in by_addr:
+        if addr not in called:
+            entries.setdefault(addr, "reachable:indirect_root")
+
+    return entries
+
+
+def _excluded_reason(func: dict) -> str | None:
+    """Return a scope-exclusion reason, or None when the function is in scope.
+
+    Only mechanical signals -- nothing name-based. A heuristic that guesses
+    "this looks like CRT" would shrink the denominator on a guess, and a
+    denominator that shrinks on a guess is how a half-read binary gets called
+    hardened.
+    """
+    if func.get("fid_match"):
+        return "excluded:fid_library"
+    if func.get("is_external"):
+        return "excluded:external"
+    if func.get("is_thunk"):
+        return "excluded:thunk"
+    if func.get("decompile_status") == _SKIPPED_STATUS:
+        return "excluded:thunk_or_external"
+    return None
+
+
+def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
+    """Forward-BFS reachability over the cached call graph.
+
+    Returns ``({canonical_address: {...}}, scope_description)``. Each record
+    carries ``name``, ``size``, ``in_scope`` and ``scope_reason``. Functions
+    excluded from scope stay in the map -- they remain retrievable through
+    ``scope="all"`` -- with an ``excluded:*`` reason.
+
+    The walk is a pure cache read: ``called_functions`` is already materialized
+    per function, so no Ghidra run is involved.
+    """
+    functions = context.get("functions") or []
+    by_addr: dict[str, dict] = {}
+    for func in functions:
+        addr = canon_addr(func.get("address"))
+        if addr:
+            by_addr[addr] = func
+
+    entries = _collect_entry_points(context, by_addr)
+
+    # Every evidenced entry point claims its own reason BEFORE any walking, so
+    # a dispatcher that also happens to be called from `entry` is still
+    # labelled a dispatcher rather than being swallowed as a plain callee.
+    # Membership is unaffected either way -- this is provenance only.
+    reasons: dict[str, str] = dict(entries)
+    for layer in ("reachable:export", "reachable:ioctl_dispatch", "reachable:indirect_root"):
+        frontier = [a for a, r in entries.items() if r == layer]
+        while frontier:
+            addr = frontier.pop()
+            func = by_addr.get(addr)
+            if func is None:
+                continue
+            for callee in func.get("called_functions") or []:
+                c_addr = canon_addr(callee.get("address"))
+                if c_addr and c_addr in by_addr and c_addr not in reasons:
+                    reasons[c_addr] = "reachable:callee"
+                    frontier.append(c_addr)
+
+    records: dict[str, dict] = {}
+    excluded_count = 0
+    unreached_count = 0
+    entry_counts: dict[str, int] = {}
+    for addr, func in by_addr.items():
+        excluded = _excluded_reason(func)
+        reason = reasons.get(addr)
+        if excluded is not None:
+            in_scope = False
+            scope_reason = excluded
+            excluded_count += 1
+        elif reason is None:
+            in_scope = False
+            scope_reason = "excluded:unreachable"
+            unreached_count += 1
+        else:
+            in_scope = True
+            scope_reason = reason
+            if reason != "reachable:callee":
+                entry_counts[reason] = entry_counts.get(reason, 0) + 1
+        records[addr] = {
+            "name": func.get("name") or "",
+            "size": int(func.get("size") or 0),
+            "in_scope": in_scope,
+            "scope_reason": scope_reason,
+        }
+
+    description = (
+        f"forward BFS over cached called_functions from "
+        f"{entry_counts.get('reachable:export', 0)} export(s), "
+        f"{entry_counts.get('reachable:ioctl_dispatch', 0)} dispatch entr(ies) and "
+        f"{entry_counts.get('reachable:indirect_root', 0)} address-taken root(s) "
+        f"with no direct caller; minus {excluded_count} thunk/external/library "
+        f"function(s)"
+    )
+    if unreached_count:
+        description += f"; {unreached_count} function(s) unreachable from any root"
+    description += ". Indirect calls are invisible to a forward walk -- scope is "
+    description += "deliberately over-approximated so the denominator never shrinks on a guess."
+
+    return records, description
+
+
+# Store
+
+
+class CoverageStore:
+    """Reads and writes ``<sha>.coverage.json`` beside the Ghidra cache."""
+
+    def __init__(self, cache):
+        """
+        Args:
+            cache: the shared :class:`ProjectCache`; supplies the cache root,
+                the sha256 identity and the analysis context.
+        """
+        self.cache = cache
+
+    # paths / identity
+
+    @property
+    def cache_dir(self) -> Path:
+        return self.cache.cache_dir
+
+    def _coverage_path(self, binary_id: str) -> Path:
+        return self.cache_dir / f"{binary_id}.coverage.json"
+
+    def binary_id_for_path(self, binary_path: str) -> str:
+        return self.cache._get_binary_hash(binary_path)
+
+    def path_for_binary_id(self, binary_id: str) -> str | None:
+        """Recover the descriptive binary path from the cache metadata side-car.
+
+        Lets a client that only has the sha256 (vr-lab's ledger key) reach the
+        analysis context without knowing where the file lived -- and keeps
+        working after the staging directory is cleaned up.
+        """
+        meta_path = self.cache_dir / f"{binary_id}.meta.json"
+        if meta_path.exists():
+            try:
+                with open(meta_path, encoding="utf-8") as handle:
+                    return json.load(handle).get("binary_path")
+            except (OSError, ValueError) as exc:
+                logger.warning("Unreadable cache metadata for %s: %s", binary_id[:12], exc)
+        stored = self.read(binary_id)
+        if stored:
+            return stored.get("binary_path")
+        return None
+
+    def resolve(
+        self,
+        binary_id: str | None = None,
+        binary_path: str | None = None,
+        fallback_path: str | None = None,
+    ) -> tuple[str | None, str | None]:
+        """Resolve ``(binary_id, binary_path)`` from whatever the caller supplied.
+
+        ``fallback_path`` is the active analysis session's binary, used when the
+        caller passed neither -- the ``binary_id=None`` case in the contract.
+        Returns ``(None, None)`` when nothing resolves.
+        """
+        if binary_id:
+            binary_id = binary_id.strip().lower()
+            if not _SHA256_RE.match(binary_id):
+                raise ValueError(
+                    f"binary_id must be a 64-char lowercase sha256 hexdigest, got {binary_id!r}"
+                )
+            return binary_id, self.path_for_binary_id(binary_id)
+
+        path = binary_path or fallback_path
+        if not path:
+            return None, None
+        try:
+            return self.binary_id_for_path(path), str(path)
+        except OSError as exc:
+            logger.warning("Could not hash %s: %s", path, exc)
+            return None, str(path)
+
+    # persistence
+
+    def read(self, binary_id: str) -> dict | None:
+        path = self._coverage_path(binary_id)
+        if not path.exists():
+            return None
+        try:
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError) as exc:
+            logger.error("Unreadable coverage side-car %s: %s", path, exc)
+            return None
+        if not isinstance(data, dict) or "functions" not in data:
+            logger.error("Malformed coverage side-car %s: no functions map", path)
+            return None
+        return data
+
+    def write(self, data: dict) -> bool:
+        """Atomically persist a coverage record.
+
+        Whole-file replace via ``os.replace`` so a reader never observes a
+        half-written ledger. There is no lock: two MCP clients marking the same
+        binary concurrently race read-modify-write in the classic way (later
+        write wins). That matches the surrounding cache's contract and vr-lab's
+        one-session-per-campaign rule; a lock is the fix if that ever changes.
+        """
+        binary_id = data.get("binary_id")
+        if not binary_id:
+            raise CoverageError("cannot write a coverage record without binary_id")
+        target = self._coverage_path(binary_id)
+        try:
+            handle = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=str(self.cache_dir),
+                prefix=f".{binary_id}.coverage.",
+                suffix=".tmp",
+                delete=False,
+            )
+            try:
+                with handle:
+                    json.dump(data, handle)
+                os.replace(handle.name, target)
+            except BaseException:
+                Path(handle.name).unlink(missing_ok=True)
+                raise
+            return True
+        except OSError as exc:
+            logger.error("Failed to write coverage side-car %s: %s", target, exc)
+            return False
+
+    # indexing
+
+    def _load_context_by_id(self, binary_id: str) -> dict | None:
+        """Read the analysis cache straight off the sha, no file needed.
+
+        ``ProjectCache.get_cached`` re-hashes the binary to find its cache, so
+        it fails once the staged file is gone. The ledger key outlives the
+        staging tree -- a consumer holding only a sha must still be able to
+        index and query -- so resolve ``<sha>.json.gz`` directly instead.
+        """
+        import gzip
+
+        for path in (
+            self.cache_dir / f"{binary_id}.json.gz",
+            self.cache_dir / f"{binary_id}.json",
+        ):
+            if not path.exists():
+                continue
+            try:
+                opener = gzip.open if path.suffix == ".gz" else open
+                with opener(path, "rt", encoding="utf-8") as handle:
+                    return json.load(handle)
+            except (OSError, ValueError) as exc:
+                logger.error("Unreadable analysis cache %s: %s", path, exc)
+                return None
+        return None
+
+    def _load_context(self, binary_path: str | None, binary_id: str | None = None) -> dict | None:
+        if binary_id:
+            context = self._load_context_by_id(binary_id)
+            if context is not None:
+                return context
+        if not binary_path:
+            return None
+        try:
+            return self.cache.get_cached(binary_path)
+        except Exception as exc:  # pragma: no cover - cache already logs
+            logger.warning("Could not load analysis cache for %s: %s", binary_path, exc)
+            return None
+
+    def _source_function_count(self, binary_id: str) -> int | None:
+        """Function count from the tiny ``<sha>.meta.json``.
+
+        Used as the cheap staleness probe so polling ``get_coverage_status``
+        never has to decompress a multi-megabyte analysis cache.
+        """
+        meta_path = self.cache_dir / f"{binary_id}.meta.json"
+        if not meta_path.exists():
+            return None
+        try:
+            with open(meta_path, encoding="utf-8") as handle:
+                value = json.load(handle).get("function_count")
+        except (OSError, ValueError):
+            return None
+        return int(value) if isinstance(value, int) else None
+
+    def index(
+        self,
+        binary_id: str,
+        binary_path: str | None,
+        context: dict | None = None,
+    ) -> dict | None:
+        """Build (or rebuild) the coverage record for a binary.
+
+        Review marks are preserved across a rebuild: an address that was
+        reviewed stays reviewed, keeping its timestamp, marking tool and note.
+        Rebuilds happen when the analysis cache grows (an incremental Ghidra
+        run) or when the scope algorithm is bumped, and neither is a reason to
+        throw away review history.
+
+        Returns the new record, or None when no analysis context is available.
+        """
+        if context is None:
+            context = self._load_context(binary_path, binary_id)
+        if not context:
+            return None
+        functions = context.get("functions") or []
+        if not functions:
+            return None
+
+        records, description = compute_scope(context)
+
+        previous = self.read(binary_id) or {}
+        prior_functions = previous.get("functions") or {}
+        for addr, record in records.items():
+            prior = prior_functions.get(addr)
+            if prior and prior.get("reviewed"):
+                record["reviewed"] = True
+                record["reviewed_at"] = prior.get("reviewed_at")
+                record["reviewed_by"] = prior.get("reviewed_by")
+                record["findings_note"] = prior.get("findings_note")
+            else:
+                record["reviewed"] = False
+                record["reviewed_at"] = None
+                record["reviewed_by"] = None
+                record["findings_note"] = prior.get("findings_note") if prior else None
+
+        metadata = context.get("metadata") or {}
+        image_base = canon_addr(metadata.get("image_base")) or None
+        resolved_path = binary_path or previous.get("binary_path") or metadata.get(
+            "executable_path"
+        )
+        module_name = metadata.get("name") or (
+            Path(resolved_path).name if resolved_path else None
+        )
+
+        data = {
+            "schema_version": SCHEMA_VERSION,
+            "binary_id": binary_id,
+            "binary_path": resolved_path,
+            "module_name": module_name,
+            "image_base": image_base,
+            "indexed_at": _utc_now(),
+            "scope_version": SCOPE_VERSION,
+            "scope_description": description,
+            "source_function_count": len(functions),
+            "functions": records,
+        }
+        self.write(data)
+        return data
+
+    def ensure_indexed(
+        self,
+        binary_id: str,
+        binary_path: str | None,
+    ) -> tuple[dict | None, str]:
+        """Return ``(record, status)``, indexing on demand when it is cheap.
+
+        - No coverage record and no analysis cache -> ``not_indexed``. Counts
+          must be reported as null, never zero: zero reads as "complete" and
+          would terminate a review loop on a binary nobody has looked at.
+        - No coverage record but an analysis cache exists -> index now. It is a
+          pure cache walk, and reporting ``not_indexed`` for a binary that is
+          already fully analyzed would strand every previously-cached target.
+        - Coverage record whose ``source_function_count`` or ``scope_version``
+          no longer matches -> re-index, preserving review marks.
+        - Coverage record with no analysis cache behind it any more -> ``stale``;
+          the counts are still returned because they are the last known truth,
+          but the consumer is told not to trust them as current.
+        """
+        record = self.read(binary_id)
+        if record is None:
+            rebuilt = self.index(binary_id, binary_path)
+            if rebuilt is None:
+                return None, STATUS_NOT_INDEXED
+            return rebuilt, STATUS_READY
+
+        cache_present = (self.cache_dir / f"{binary_id}.json.gz").exists() or (
+            self.cache_dir / f"{binary_id}.json"
+        ).exists()
+        if not cache_present:
+            # The analysis this ledger counted has been evicted. Return the
+            # last known counts -- they are still the best available truth --
+            # but flag them as not current so nobody concludes on them.
+            return record, STATUS_STALE
+
+        source_count = self._source_function_count(binary_id)
+        stale_scope = record.get("scope_version") != SCOPE_VERSION
+        stale_count = (
+            source_count is not None
+            and record.get("source_function_count") is not None
+            and source_count != record.get("source_function_count")
+        )
+        if stale_scope or stale_count:
+            rebuilt = self.index(binary_id, binary_path or record.get("binary_path"))
+            if rebuilt is not None:
+                return rebuilt, STATUS_READY
+            return record, STATUS_STALE
+
+        return record, STATUS_READY
+
+    # counting
+
+    @staticmethod
+    def counts(record: dict) -> dict[str, int]:
+        """Derive the six count fields and assert the contract invariants."""
+        functions = record.get("functions") or {}
+        total = len(functions)
+        in_scope_total = 0
+        reviewed = 0
+        reviewed_in_scope = 0
+        for entry in functions.values():
+            in_scope = bool(entry.get("in_scope"))
+            is_reviewed = bool(entry.get("reviewed"))
+            if in_scope:
+                in_scope_total += 1
+            if is_reviewed:
+                reviewed += 1
+                if in_scope:
+                    reviewed_in_scope += 1
+
+        counts = {
+            "total": total,
+            "in_scope_total": in_scope_total,
+            "reviewed": reviewed,
+            "reviewed_in_scope": reviewed_in_scope,
+            "remaining": total - reviewed,
+            "remaining_in_scope": in_scope_total - reviewed_in_scope,
+        }
+        _assert_invariants(counts)
+        return counts
+
+    # marking
+
+    def mark_reviewed(
+        self,
+        binary_id: str,
+        addresses,
+        tool: str,
+        note: str | None = None,
+        reviewed: bool = True,
+    ) -> dict:
+        """Mark functions reviewed (idempotent).
+
+        Returns ``{"marked": [...], "already": [...], "unknown": [...]}``.
+        Addresses absent from the function map are reported as ``unknown`` and
+        never inserted -- a phantom entry would push ``reviewed`` above
+        ``total`` and break the invariants the consumer asserts on.
+        """
+        record = self.read(binary_id)
+        if record is None:
+            return {"marked": [], "already": [], "unknown": [canon_addr(a) for a in addresses]}
+
+        functions = record.get("functions") or {}
+        marked: list[str] = []
+        already: list[str] = []
+        unknown: list[str] = []
+
+        for raw in addresses:
+            addr = canon_addr(raw)
+            if not addr or addr not in functions:
+                unknown.append(addr or str(raw))
+                continue
+            entry = functions[addr]
+            if note is not None:
+                entry["findings_note"] = note
+            if bool(entry.get("reviewed")) == reviewed:
+                # Idempotent: re-decompiling does not double-count, and does
+                # not rewrite the original review timestamp.
+                already.append(addr)
+                continue
+            entry["reviewed"] = reviewed
+            entry["reviewed_at"] = _utc_now() if reviewed else None
+            entry["reviewed_by"] = tool if reviewed else None
+            marked.append(addr)
+
+        if marked or note is not None:
+            self.write(record)
+
+        return {"marked": marked, "already": already, "unknown": unknown}
+
+
+def auto_mark(
+    cache,
+    binary_path: str | None,
+    addresses,
+    tool: str,
+    context: dict | None = None,
+) -> None:
+    """Best-effort auto-mark hook for the per-function analysis tools.
+
+    Called for its side effect only: coverage must never be able to break an
+    analysis tool, so every failure here is logged and swallowed. Callers pass
+    the ``context`` they already hold so indexing a not-yet-indexed binary does
+    not re-read and decompress the analysis cache on the hot path.
+
+    See ``docs/coverage.md`` for the auto-marking tool set and why the
+    whole-binary sweeps are deliberately not in it.
+    """
+    try:
+        addresses = [a for a in (canon_addr(x) for x in addresses) if a]
+        if not addresses or not binary_path:
+            return
+        store = CoverageStore(cache)
+        binary_id = store.binary_id_for_path(binary_path)
+        if store.read(binary_id) is None:
+            if store.index(binary_id, binary_path, context=context) is None:
+                return
+        store.mark_reviewed(binary_id, addresses, tool=tool)
+    except Exception as exc:
+        logger.warning("auto-mark (%s) failed for %s: %s", tool, binary_path, exc)
+
+
+def _assert_invariants(counts: dict[str, int]) -> None:
+    """Fail loudly on an inconsistent count set.
+
+    The consumer treats an invariant violation as a hard error; producing one
+    server-side would be worse than crashing, so this raises rather than logs.
+    """
+    for key, value in counts.items():
+        if not isinstance(value, int) or value < 0:
+            raise CoverageError(f"coverage count {key}={value!r} is not a non-negative int")
+    if counts["remaining"] != counts["total"] - counts["reviewed"]:
+        raise CoverageError("invariant violated: remaining != total - reviewed")
+    if counts["remaining_in_scope"] != counts["in_scope_total"] - counts["reviewed_in_scope"]:
+        raise CoverageError(
+            "invariant violated: remaining_in_scope != in_scope_total - reviewed_in_scope"
+        )
+    if counts["in_scope_total"] > counts["total"]:
+        raise CoverageError("invariant violated: in_scope_total > total")
+    if counts["reviewed_in_scope"] > counts["reviewed"]:
+        raise CoverageError("invariant violated: reviewed_in_scope > reviewed")

--- a/src/engines/static/ghidra/coverage_store.py
+++ b/src/engines/static/ghidra/coverage_store.py
@@ -227,6 +227,50 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
                     reasons[c_addr] = "reachable:callee"
                     frontier.append(c_addr)
 
+    # The layered walk above cannot enter a call cycle that is only reachable
+    # indirectly. `reachable:indirect_root` means "no direct caller anywhere",
+    # and every member of a cycle has one -- itself, or its partner -- so no
+    # cycle member is ever promoted, the walk never enters, and the entire
+    # subtree below it drops out as `excluded:unreachable`. That SHRINKS the
+    # denominator, the one direction this scope must never move: on the cached
+    # corpus it was silently dropping http.sys parsers and the chakra GC.
+    #
+    # Promote the residual to roots until a fixpoint. Prefer genuine sources --
+    # residual functions with no caller inside the residual -- so provenance
+    # stays meaningful; a pure cycle with no source is broken at its lowest
+    # address, which keeps the result deterministic for a resuming client.
+    while True:
+        residual = {
+            a for a in by_addr
+            if a not in reasons and _excluded_reason(by_addr[a]) is None
+        }
+        if not residual:
+            break
+        called_within = set()
+        for a in residual:
+            for callee in by_addr[a].get("called_functions") or []:
+                c_addr = canon_addr(callee.get("address"))
+                if c_addr and c_addr in residual:
+                    called_within.add(c_addr)
+        sources = sorted(residual - called_within, key=lambda x: int(x, 16))
+        if not sources:
+            sources = [min(residual, key=lambda x: int(x, 16))]
+        for root in sources:
+            if root in reasons:
+                continue
+            reasons[root] = "reachable:cycle_root"
+            frontier = [root]
+            while frontier:
+                addr = frontier.pop()
+                func = by_addr.get(addr)
+                if func is None:
+                    continue
+                for callee in func.get("called_functions") or []:
+                    c_addr = canon_addr(callee.get("address"))
+                    if c_addr and c_addr in by_addr and c_addr not in reasons:
+                        reasons[c_addr] = "reachable:callee"
+                        frontier.append(c_addr)
+
     records: dict[str, dict] = {}
     excluded_count = 0
     unreached_count = 0
@@ -259,13 +303,25 @@ def compute_scope(context: dict) -> tuple[dict[str, dict], str]:
         f"{entry_counts.get('reachable:export', 0)} export(s), "
         f"{entry_counts.get('reachable:ioctl_dispatch', 0)} dispatch entr(ies) and "
         f"{entry_counts.get('reachable:indirect_root', 0)} address-taken root(s) "
-        f"with no direct caller; minus {excluded_count} thunk/external/library "
-        f"function(s)"
+        f"with no direct caller"
     )
+    if entry_counts.get("reachable:cycle_root"):
+        description += (
+            f" and {entry_counts['reachable:cycle_root']} cycle root(s) promoted "
+            f"after the walk settled"
+        )
+    description += f"; minus {excluded_count} thunk/external/library function(s)"
     if unreached_count:
-        description += f"; {unreached_count} function(s) unreachable from any root"
-    description += ". Indirect calls are invisible to a forward walk -- scope is "
-    description += "deliberately over-approximated so the denominator never shrinks on a guess."
+        description += (
+            f"; {unreached_count} function(s) still unreachable from any root "
+            f"(expected 0 -- a non-zero count here means the fixpoint failed to "
+            f"converge and the denominator is under-counted)"
+        )
+    description += ". Indirect calls are invisible to a forward walk, so scope is "
+    description += (
+        "over-approximated on purpose: unreached functions are promoted to roots "
+        "until nothing is left, and the denominator never shrinks on a guess."
+    )
 
     return records, description
 

--- a/src/engines/static/ghidra/project_cache.py
+++ b/src/engines/static/ghidra/project_cache.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Side-car suffixes that share the <hash>.<suffix> stem with a cache file.
 # When auto-pruning legacy <hash>.json duplicates we must NOT touch these.
-_SIDECAR_SUFFIXES = (".meta.json", ".funcidx.json", ".notes.json")
+_SIDECAR_SUFFIXES = (".meta.json", ".funcidx.json", ".notes.json", ".coverage.json")
 
 
 class ProjectCache:

--- a/src/server.py
+++ b/src/server.py
@@ -1,7 +1,7 @@
 """
 Binary MCP Server for comprehensive binary analysis.
 
-Provides 249 tools for static and dynamic binary analysis:
+Provides 250 tools for static and dynamic binary analysis:
 - Static analysis via Ghidra (headless mode) for native binaries
 - Static analysis via ILSpyCmd for .NET assemblies
 - Dynamic analysis via x64dbg (native plugin)

--- a/src/server.py
+++ b/src/server.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from fastmcp import FastMCP
 
 from src.engines.session import AnalysisType, UnifiedSessionManager
-from src.engines.static.ghidra.coverage_store import CoverageStore
+from src.engines.static.ghidra.coverage_store import CoverageStore, has_reviewable_body
 from src.engines.static.ghidra.coverage_store import auto_mark as auto_mark_reviewed
 from src.engines.static.ghidra.project_cache import ProjectCache
 from src.engines.static.ghidra.runner import GhidraAnalysisError, GhidraRunner
@@ -1965,11 +1965,14 @@ def decompile_function(
 
         # Coverage side effect: the pseudocode is about to be handed to the
         # caller, so this function counts as reviewed. Best-effort -- never
-        # let the ledger break a decompile.
-        auto_mark_reviewed(
-            cache, binary_path, [function.get("address")],
-            tool="decompile_function", context=context,
-        )
+        # let the ledger break a decompile. A body that is only a decompiler
+        # banner comment is still returned, but showing a remark about the
+        # function is not showing the function, so it does not mark.
+        if has_reviewable_body(pseudocode):
+            auto_mark_reviewed(
+                cache, binary_path, [function.get("address")],
+                tool="decompile_function", context=context,
+            )
 
         # Format output
         result = f"**Decompiled: {function_name}**\n\n"

--- a/src/server.py
+++ b/src/server.py
@@ -1,13 +1,14 @@
 """
 Binary MCP Server for comprehensive binary analysis.
 
-Provides 245 tools for static and dynamic binary analysis:
+Provides 249 tools for static and dynamic binary analysis:
 - Static analysis via Ghidra (headless mode) for native binaries
 - Static analysis via ILSpyCmd for .NET assemblies
 - Dynamic analysis via x64dbg (native plugin)
 - Control flow analysis (CFG, cyclomatic complexity, loops, dead code)
 - Malware behavior detection (10 categories, anti-analysis, API call chains)
 - Function hashing and cross-binary matching
+- Review coverage (per-binary denominator, scope, unreviewed worklist)
 """
 
 import contextlib
@@ -24,9 +25,12 @@ from pathlib import Path
 from fastmcp import FastMCP
 
 from src.engines.session import AnalysisType, UnifiedSessionManager
+from src.engines.static.ghidra.coverage_store import CoverageStore
+from src.engines.static.ghidra.coverage_store import auto_mark as auto_mark_reviewed
 from src.engines.static.ghidra.project_cache import ProjectCache
 from src.engines.static.ghidra.runner import GhidraAnalysisError, GhidraRunner
 from src.tools.control_flow_tools import register_control_flow_tools
+from src.tools.coverage_tools import register_coverage_tools
 from src.tools.diff_tools import register_diff_tools
 from src.tools.dispatch_tools import register_dispatch_tools
 from src.tools.dotnet_tools import register_dotnet_tools
@@ -722,6 +726,21 @@ def get_analysis_context(
             cache.save_cached(binary_path, context)
         except Exception as e:
             logger.warning(f"Failed to apply notes overlay after analysis: {e}")
+
+        # Populate the review-coverage function list off the fresh context.
+        # Best-effort and never fatal: coverage is additive, and a ledger
+        # failure must not sink an analysis that otherwise succeeded. Review
+        # marks survive the rebuild, so an incremental run that grows the
+        # function list extends the denominator without losing history.
+        try:
+            coverage_store = CoverageStore(cache)
+            coverage_store.index(
+                coverage_store.binary_id_for_path(binary_path),
+                binary_path,
+                context=context,
+            )
+        except Exception as e:
+            logger.warning(f"Coverage indexing failed for {binary_path}: {e}")
 
         # Clean up temp file
         output_path.unlink()
@@ -1943,6 +1962,14 @@ def decompile_function(
                     f"Function '{function_name}' could not be decompiled "
                     f"(decompilation may have failed)."
                 )
+
+        # Coverage side effect: the pseudocode is about to be handed to the
+        # caller, so this function counts as reviewed. Best-effort -- never
+        # let the ledger break a decompile.
+        auto_mark_reviewed(
+            cache, binary_path, [function.get("address")],
+            tool="decompile_function", context=context,
+        )
 
         # Format output
         result = f"**Decompiled: {function_name}**\n\n"
@@ -4628,7 +4655,10 @@ def main():
     # Register Function ID (FID) library-match reader
     register_fid_tools(app, session_manager, cache, runner)
 
-    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash, PE structure, review, fid)")
+    # Register review-coverage tools (denominator + worklist)
+    register_coverage_tools(app, session_manager, cache, runner)
+
+    logger.info("Registered all analysis tools (static, dynamic, VT, triage, reporting, Yara, control flow, malware, function hash, PE structure, review, fid, coverage)")
     logger.info(f"Session Directory: {session_manager.store_dir}")
 
     # Run the FastMCP server (handles stdio automatically)

--- a/src/tools/coverage_tools.py
+++ b/src/tools/coverage_tools.py
@@ -31,7 +31,6 @@ false completion this store exists to prevent.
 
 from __future__ import annotations
 
-import json
 import logging
 
 from src.engines.static.ghidra.coverage_store import (
@@ -53,12 +52,9 @@ logger = logging.getLogger(__name__)
 MAX_WORKLIST = 500
 
 
-def _json(payload: dict) -> str:
-    return json.dumps(payload, indent=2)
-
-
-def _error(message: str, **extra) -> str:
-    return _json({"error": message, **extra})
+def _error(message: str, **extra) -> dict:
+    """Errors share the payload shape: a flat object carrying an `error` key."""
+    return {"error": message, **extra}
 
 
 def register_coverage_tools(app, session_manager, cache, runner=None):
@@ -96,7 +92,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
     def get_coverage_status(
         binary_id: str | None = None,
         binary_path: str | None = None,
-    ) -> str:
+    ) -> dict:
         """
         Report review coverage for one binary: the denominator and what's left.
 
@@ -171,7 +167,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
                 "Binary has not been analyzed. Run analyze_binary first; "
                 "coverage indexes automatically from the analysis cache."
             )
-            return _json(base)
+            return base
 
         payload = dict(base)
         payload.update(
@@ -186,7 +182,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             }
         )
         payload.update(store.counts(record))
-        return _json(payload)
+        return payload
 
     @app.tool()
     def get_next_unreviewed(
@@ -194,7 +190,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
         count: int = 20,
         scope: str = "in_scope",
         binary_path: str | None = None,
-    ) -> str:
+    ) -> dict:
         """
         Return the next batch of functions that have not been reviewed yet.
 
@@ -243,16 +239,14 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             return _error(f"Coverage lookup failed: {exc}")
 
         if record is None:
-            return _json(
-                {
-                    "binary_id": resolved_id,
-                    "scope": scope,
-                    "returned": 0,
-                    "remaining_after": None,
-                    "functions": [],
-                    "status": status,
-                }
-            )
+            return {
+                "binary_id": resolved_id,
+                "scope": scope,
+                "returned": 0,
+                "remaining_after": None,
+                "functions": [],
+                "status": status,
+            }
 
         functions = record.get("functions") or {}
         pending = [
@@ -263,31 +257,29 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
         pending.sort(key=lambda item: item[0])
 
         batch = pending[:count]
-        return _json(
-            {
-                "binary_id": resolved_id,
-                "scope": scope,
-                "returned": len(batch),
-                "remaining_after": len(pending) - len(batch),
-                "functions": [
-                    {
-                        "address": addr,
-                        "name": entry.get("name"),
-                        "size": entry.get("size"),
-                        "in_scope": bool(entry.get("in_scope")),
-                        "scope_reason": entry.get("scope_reason"),
-                    }
-                    for _, addr, entry in batch
-                ],
-                "status": status,
-            }
-        )
+        return {
+            "binary_id": resolved_id,
+            "scope": scope,
+            "returned": len(batch),
+            "remaining_after": len(pending) - len(batch),
+            "functions": [
+                {
+                    "address": addr,
+                    "name": entry.get("name"),
+                    "size": entry.get("size"),
+                    "in_scope": bool(entry.get("in_scope")),
+                    "scope_reason": entry.get("scope_reason"),
+                }
+                for _, addr, entry in batch
+            ],
+            "status": status,
+        }
 
     @app.tool()
     def coverage_index(
         binary_path: str,
         force: bool = False,
-    ) -> str:
+    ) -> dict:
         """
         Build or rebuild the coverage index for an already-analyzed binary.
 
@@ -340,7 +332,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             "status": "ready",
         }
         payload.update(store.counts(record))
-        return _json(payload)
+        return payload
 
     @app.tool()
     def mark_function_reviewed(
@@ -349,7 +341,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
         binary_path: str | None = None,
         note: str | None = None,
         reviewed: bool = True,
-    ) -> str:
+    ) -> dict:
         """
         Manually mark functions reviewed (or clear the mark).
 
@@ -416,6 +408,6 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
 
         payload = {"binary_id": resolved_id, "status": status, **result}
         payload.update(store.counts(refreshed))
-        return _json(payload)
+        return payload
 
     logger.info("Registered 4 coverage tools")

--- a/src/tools/coverage_tools.py
+++ b/src/tools/coverage_tools.py
@@ -13,6 +13,7 @@ Tools
 ``get_next_unreviewed``  -- deterministic worklist, ascending address.
 ``coverage_index``       -- explicit (re)index; normally automatic.
 ``mark_function_reviewed`` -- manual mark / unmark, optional findings note.
+``reset_coverage``       -- clear the marks; the undo for a contaminated ledger.
 
 Auto-marking
 ------------
@@ -410,4 +411,72 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
         payload.update(store.counts(refreshed))
         return payload
 
-    logger.info("Registered 4 coverage tools")
+    @app.tool()
+    def reset_coverage(
+        binary_id: str | None = None,
+        binary_path: str | None = None,
+        drop_index: bool = False,
+    ) -> dict:
+        """
+        Clear the review marks for a binary. The undo for a contaminated ledger.
+
+        Use when marks landed that do not reflect anyone actually reading the
+        code -- a scripted sweep, a verification run pointed at the wrong file,
+        a pass that was retracted. An inflated denominator is worse than none:
+        the next campaign reads "fully reviewed" and stops on a binary nobody
+        read, which is the exact failure coverage exists to prevent.
+
+        This is destructive and takes effect immediately. It does not touch the
+        Ghidra analysis cache. To clear specific functions rather than all of
+        them, use ``mark_function_reviewed(..., reviewed=False)``.
+
+        Args:
+            binary_id: Lowercase sha256 hexdigest of the binary's bytes.
+            binary_path: Optional path alternative to ``binary_id``.
+            drop_index: Also discard the function list and stored scope, so the
+                next query re-indexes from the analysis cache. Use when the
+                index itself is suspect, not just the marks.
+
+        Returns:
+            JSON with ``cleared`` (how many functions had a mark or note),
+            ``dropped`` (whether the record was deleted) and the refreshed
+            counts. Clearing an already-clean ledger reports ``cleared: 0``
+            rather than failing.
+        """
+        try:
+            resolved_id, resolved_path = _resolve(binary_id, binary_path)
+        except ValueError as exc:
+            return _error(str(exc))
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as exc:
+            return _error(f"Invalid binary path: {exc}")
+
+        if not resolved_id:
+            return _error("No binary resolved. Pass binary_id or binary_path.")
+
+        try:
+            existing = store.read(resolved_id)
+            if existing is None:
+                return _error(
+                    "No coverage record for this binary; nothing to reset.",
+                    binary_id=resolved_id,
+                    status="not_indexed",
+                )
+            cleared = store.reset_marks(resolved_id)
+            dropped = store.drop(resolved_id) if drop_index else False
+            record, status = store.ensure_indexed(resolved_id, resolved_path)
+        except Exception as exc:
+            logger.exception("reset_coverage failed")
+            return _error(f"Reset failed: {exc}")
+
+        payload = {
+            "binary_id": resolved_id,
+            "binary_path": (record or {}).get("binary_path") or resolved_path,
+            "cleared": cleared,
+            "dropped": dropped,
+            "status": status if record is not None else "not_indexed",
+        }
+        if record is not None:
+            payload.update(store.counts(record))
+        return payload
+
+    logger.info("Registered 5 coverage tools")

--- a/src/tools/coverage_tools.py
+++ b/src/tools/coverage_tools.py
@@ -58,6 +58,25 @@ def _error(message: str, **extra) -> dict:
     return {"error": message, **extra}
 
 
+def _null_counts() -> dict:
+    """The six counts, explicitly null.
+
+    Every payload that reports counts starts from this, so a key is never
+    merely absent. A consumer reading `payload.get("total", 0)` off a response
+    that omitted the key lands on 0, and 0 reads as "complete" -- the same
+    false-completion failure the null-not-zero rule exists to prevent, arrived
+    at through the client's default instead of the server's value.
+    """
+    return {
+        "total": None,
+        "in_scope_total": None,
+        "reviewed": None,
+        "reviewed_in_scope": None,
+        "remaining": None,
+        "remaining_in_scope": None,
+    }
+
+
 def register_coverage_tools(app, session_manager, cache, runner=None):
     """
     Register the coverage tools with the MCP app.
@@ -125,6 +144,12 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             ``remaining_in_scope == 0`` means the in-scope worklist is finished,
             not that the binary is. Indirect calls are invisible to a forward
             call-graph walk, so full closure still consults ``remaining``.
+
+            ``dropped_address_count`` is how many functions the analysis cache
+            listed that are missing from ``total`` because their address could
+            not be parsed. It is 0 on every binary seen so far; a non-zero value
+            means ``total`` under-counts the binary by that much and no
+            completion claim should be made on it.
         """
         try:
             resolved_id, resolved_path = _resolve(binary_id, binary_path)
@@ -144,12 +169,8 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             "binary_path": resolved_path,
             "module_name": None,
             "image_base": None,
-            "total": None,
-            "in_scope_total": None,
-            "reviewed": None,
-            "reviewed_in_scope": None,
-            "remaining": None,
-            "remaining_in_scope": None,
+            **_null_counts(),
+            "dropped_address_count": None,
             "scope_description": None,
             "scope_version": SCOPE_VERSION,
             "indexed_at": None,
@@ -179,6 +200,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
                 "scope_description": record.get("scope_description"),
                 "scope_version": record.get("scope_version"),
                 "indexed_at": record.get("indexed_at"),
+                "dropped_address_count": record.get("dropped_address_count"),
                 "status": status,
             }
         )
@@ -330,6 +352,7 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             "scope_description": record.get("scope_description"),
             "scope_version": record.get("scope_version"),
             "indexed_at": record.get("indexed_at"),
+            "dropped_address_count": record.get("dropped_address_count"),
             "status": "ready",
         }
         payload.update(store.counts(record))
@@ -435,13 +458,15 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
             binary_path: Optional path alternative to ``binary_id``.
             drop_index: Also discard the function list and stored scope, so the
                 next query re-indexes from the analysis cache. Use when the
-                index itself is suspect, not just the marks.
+                index itself is suspect, not just the marks. Refused when the
+                analysis cache is gone, because then nothing can rebuild it.
 
         Returns:
             JSON with ``cleared`` (how many functions had a mark or note),
             ``dropped`` (whether the record was deleted) and the refreshed
             counts. Clearing an already-clean ledger reports ``cleared: 0``
-            rather than failing.
+            rather than failing. The six count keys are always present, null
+            when no record could be read.
         """
         try:
             resolved_id, resolved_path = _resolve(binary_id, binary_path)
@@ -460,19 +485,43 @@ def register_coverage_tools(app, session_manager, cache, runner=None):
                     "No coverage record for this binary; nothing to reset.",
                     binary_id=resolved_id,
                     status="not_indexed",
+                    **_null_counts(),
+                )
+            if drop_index and not store.has_analysis_cache(resolved_id):
+                # Dropping is only survivable because the analysis cache can
+                # rebuild the record. Without it the delete is final, and the
+                # record being deleted is the last surviving account of what
+                # was reviewed -- `ProjectCache.invalidate` evicts the analysis
+                # and deliberately spares this side-car, so a `stale` ledger is
+                # exactly the recoverable state this would destroy. Refuse
+                # rather than trade a stale denominator for no denominator.
+                return _error(
+                    "Refusing drop_index: the analysis cache for this binary is "
+                    "gone, so the record cannot be rebuilt and this coverage "
+                    "record is the last surviving account of what was reviewed. "
+                    "Re-run analyze_binary to restore the rebuild source, or "
+                    "call reset_coverage without drop_index to clear the marks "
+                    "while keeping the denominator.",
+                    binary_id=resolved_id,
+                    binary_path=existing.get("binary_path") or resolved_path,
+                    cleared=0,
+                    dropped=False,
+                    status="stale",
+                    **_null_counts(),
                 )
             cleared = store.reset_marks(resolved_id)
             dropped = store.drop(resolved_id) if drop_index else False
             record, status = store.ensure_indexed(resolved_id, resolved_path)
         except Exception as exc:
             logger.exception("reset_coverage failed")
-            return _error(f"Reset failed: {exc}")
+            return _error(f"Reset failed: {exc}", **_null_counts())
 
         payload = {
             "binary_id": resolved_id,
             "binary_path": (record or {}).get("binary_path") or resolved_path,
             "cleared": cleared,
             "dropped": dropped,
+            **_null_counts(),
             "status": status if record is not None else "not_indexed",
         }
         if record is not None:

--- a/src/tools/coverage_tools.py
+++ b/src/tools/coverage_tools.py
@@ -1,0 +1,421 @@
+"""
+Review-coverage MCP tools.
+
+binary-mcp owns the coverage denominator: how many functions a binary has, how
+many are in scope, and how many have been reviewed. These tools expose it.
+Unlike the rest of the server they return **JSON**, not markdown -- the
+consumer (vr-lab's notes-mcp ledger) mirrors the count fields directly and
+asserts invariants on them, so a prose report would be the wrong shape.
+
+Tools
+-----
+``get_coverage_status``  -- the six counts plus scope provenance.
+``get_next_unreviewed``  -- deterministic worklist, ascending address.
+``coverage_index``       -- explicit (re)index; normally automatic.
+``mark_function_reviewed`` -- manual mark / unmark, optional findings note.
+
+Auto-marking
+------------
+These tools mark a function reviewed as a side effect:
+
+    decompile_function, batch_decompile, get_review_package, get_param_sinks
+
+They are the calls that hand a model the function's actual body or a semantic
+per-function analysis of it. Everything else -- ``get_functions``,
+``get_imports``, ``get_strings``, ``get_function_callers``,
+``analyze_function_completeness``, and the whole-binary ``scan_pseudocode``
+sweep -- does NOT auto-mark. Seeing a function in a list is not reviewing it,
+and a regex sweep that "reviewed" 3000 functions would manufacture exactly the
+false completion this store exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from src.engines.static.ghidra.coverage_store import (
+    SCOPE_VERSION,
+    CoverageStore,
+    canon_addr,
+)
+from src.utils.security import (
+    FileSizeError,
+    PathTraversalError,
+    sanitize_binary_path,
+    validate_numeric_range,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cap on one worklist batch. Large enough for a real pass, small enough that a
+# poll cannot bury the model.
+MAX_WORKLIST = 500
+
+
+def _json(payload: dict) -> str:
+    return json.dumps(payload, indent=2)
+
+
+def _error(message: str, **extra) -> str:
+    return _json({"error": message, **extra})
+
+
+def register_coverage_tools(app, session_manager, cache, runner=None):
+    """
+    Register the coverage tools with the MCP app.
+
+    Args:
+        app: FastMCP instance.
+        session_manager: used only to resolve the active session's binary when
+            the caller supplies neither ``binary_id`` nor ``binary_path``.
+        cache: ProjectCache -- supplies the cache root, the sha256 identity and
+            the analysis context.
+        runner: accepted for signature parity with the sibling
+            ``register_*_tools`` entry points; coverage is strictly cache-only
+            and never invokes Ghidra.
+    """
+    del runner
+
+    store = CoverageStore(cache)
+
+    def _session_binary() -> str | None:
+        return getattr(session_manager, "_current_binary_path", None)
+
+    def _resolve(binary_id: str | None, binary_path: str | None):
+        """Resolve identity, validating any caller-supplied path."""
+        if binary_path:
+            binary_path = str(sanitize_binary_path(binary_path))
+        return store.resolve(
+            binary_id=binary_id,
+            binary_path=binary_path,
+            fallback_path=_session_binary(),
+        )
+
+    @app.tool()
+    def get_coverage_status(
+        binary_id: str | None = None,
+        binary_path: str | None = None,
+    ) -> str:
+        """
+        Report review coverage for one binary: the denominator and what's left.
+
+        Answers "how much of this binary has actually been read?" with numbers
+        that survive a restart. binary-mcp owns these counts; a consumer should
+        mirror them rather than recompute a total from its own mark count.
+
+        Args:
+            binary_id: Lowercase sha256 hexdigest of the binary's bytes (64
+                chars). Optional.
+            binary_path: Path to the binary. Optional convenience for clients
+                that hold a path rather than a hash.
+            When both are omitted, resolves the active analysis session's
+            binary.
+
+        Returns:
+            JSON with ``binary_id``, ``binary_path``, ``module_name``,
+            ``image_base``, the six counts (``total``, ``in_scope_total``,
+            ``reviewed``, ``reviewed_in_scope``, ``remaining``,
+            ``remaining_in_scope``), ``scope_description``, ``scope_version``,
+            ``indexed_at`` and ``status``.
+
+            ``status`` is ``ready`` | ``not_indexed`` | ``indexing`` |
+            ``stale``. On anything other than ``ready`` **all six counts are
+            null, never zero** -- zero would read as "complete" and terminate a
+            review loop on a binary nobody has looked at. Treat a non-ready
+            status as "cannot conclude", not "done".
+
+            ``remaining_in_scope == 0`` means the in-scope worklist is finished,
+            not that the binary is. Indirect calls are invisible to a forward
+            call-graph walk, so full closure still consults ``remaining``.
+        """
+        try:
+            resolved_id, resolved_path = _resolve(binary_id, binary_path)
+        except ValueError as exc:
+            return _error(str(exc))
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as exc:
+            return _error(f"Invalid binary path: {exc}")
+
+        if not resolved_id:
+            return _error(
+                "No binary resolved. Pass binary_id or binary_path, or run an "
+                "analysis tool first so a session binary exists."
+            )
+
+        base = {
+            "binary_id": resolved_id,
+            "binary_path": resolved_path,
+            "module_name": None,
+            "image_base": None,
+            "total": None,
+            "in_scope_total": None,
+            "reviewed": None,
+            "reviewed_in_scope": None,
+            "remaining": None,
+            "remaining_in_scope": None,
+            "scope_description": None,
+            "scope_version": SCOPE_VERSION,
+            "indexed_at": None,
+            "status": "not_indexed",
+        }
+
+        try:
+            record, status = store.ensure_indexed(resolved_id, resolved_path)
+        except Exception as exc:
+            logger.exception("get_coverage_status failed")
+            return _error(f"Coverage lookup failed: {exc}", **base)
+
+        if record is None:
+            base["status"] = status
+            base["scope_description"] = (
+                "Binary has not been analyzed. Run analyze_binary first; "
+                "coverage indexes automatically from the analysis cache."
+            )
+            return _json(base)
+
+        payload = dict(base)
+        payload.update(
+            {
+                "binary_path": record.get("binary_path") or resolved_path,
+                "module_name": record.get("module_name"),
+                "image_base": record.get("image_base"),
+                "scope_description": record.get("scope_description"),
+                "scope_version": record.get("scope_version"),
+                "indexed_at": record.get("indexed_at"),
+                "status": status,
+            }
+        )
+        payload.update(store.counts(record))
+        return _json(payload)
+
+    @app.tool()
+    def get_next_unreviewed(
+        binary_id: str | None = None,
+        count: int = 20,
+        scope: str = "in_scope",
+        binary_path: str | None = None,
+    ) -> str:
+        """
+        Return the next batch of functions that have not been reviewed yet.
+
+        Ordering is ascending numeric address -- deterministic and stable, so a
+        client that crashes mid-batch and re-calls gets the same head of the
+        queue and makes forward progress once those are marked.
+
+        Args:
+            binary_id: Lowercase sha256 hexdigest of the binary's bytes.
+            count: Batch size (1-500, default 20).
+            scope: ``"in_scope"`` (default) for the reachability-filtered
+                worklist, or ``"all"`` to include thunk / library / unreachable
+                functions. Excluded functions stay retrievable through
+                ``"all"`` precisely so an under-counted scope cannot hide work.
+            binary_path: Optional path alternative to ``binary_id``.
+
+        Returns:
+            JSON with ``binary_id``, ``scope``, ``returned``,
+            ``remaining_after`` and a ``functions`` list of
+            ``{address, name, size, in_scope, scope_reason}``.
+
+            ``functions: []`` with ``remaining_after: 0`` is the terminal
+            condition. A ``status`` other than ``ready`` means the binary is not
+            indexed -- do not read an empty list as completion.
+        """
+        if scope not in ("in_scope", "all"):
+            return _error(f"scope must be 'in_scope' or 'all', got {scope!r}")
+        try:
+            count = validate_numeric_range(count, 1, MAX_WORKLIST, "count")
+            resolved_id, resolved_path = _resolve(binary_id, binary_path)
+        except ValueError as exc:
+            return _error(str(exc))
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as exc:
+            return _error(f"Invalid binary path: {exc}")
+
+        if not resolved_id:
+            return _error(
+                "No binary resolved. Pass binary_id or binary_path, or run an "
+                "analysis tool first so a session binary exists."
+            )
+
+        try:
+            record, status = store.ensure_indexed(resolved_id, resolved_path)
+        except Exception as exc:
+            logger.exception("get_next_unreviewed failed")
+            return _error(f"Coverage lookup failed: {exc}")
+
+        if record is None:
+            return _json(
+                {
+                    "binary_id": resolved_id,
+                    "scope": scope,
+                    "returned": 0,
+                    "remaining_after": None,
+                    "functions": [],
+                    "status": status,
+                }
+            )
+
+        functions = record.get("functions") or {}
+        pending = [
+            (int(addr, 16), addr, entry)
+            for addr, entry in functions.items()
+            if not entry.get("reviewed") and (scope == "all" or entry.get("in_scope"))
+        ]
+        pending.sort(key=lambda item: item[0])
+
+        batch = pending[:count]
+        return _json(
+            {
+                "binary_id": resolved_id,
+                "scope": scope,
+                "returned": len(batch),
+                "remaining_after": len(pending) - len(batch),
+                "functions": [
+                    {
+                        "address": addr,
+                        "name": entry.get("name"),
+                        "size": entry.get("size"),
+                        "in_scope": bool(entry.get("in_scope")),
+                        "scope_reason": entry.get("scope_reason"),
+                    }
+                    for _, addr, entry in batch
+                ],
+                "status": status,
+            }
+        )
+
+    @app.tool()
+    def coverage_index(
+        binary_path: str,
+        force: bool = False,
+    ) -> str:
+        """
+        Build or rebuild the coverage index for an already-analyzed binary.
+
+        Normally unnecessary: coverage indexes itself after ``analyze_binary``
+        and on first status query. Use this to force a rebuild after changing
+        the scope algorithm, or to pre-warm the ledger.
+
+        Review marks are preserved across a rebuild -- an address that was
+        reviewed stays reviewed, with its original timestamp and note.
+
+        Args:
+            binary_path: Path to a binary that has already been analyzed.
+            force: Rebuild even when a current index exists.
+
+        Returns:
+            JSON with the resulting counts, or an error when the binary has no
+            analysis cache.
+        """
+        try:
+            path = str(sanitize_binary_path(binary_path))
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as exc:
+            return _error(f"Invalid binary path: {exc}")
+
+        try:
+            binary_id = store.binary_id_for_path(path)
+            if force or store.read(binary_id) is None:
+                record = store.index(binary_id, path)
+            else:
+                record, _status = store.ensure_indexed(binary_id, path)
+        except Exception as exc:
+            logger.exception("coverage_index failed")
+            return _error(f"Coverage index failed: {exc}")
+
+        if record is None:
+            return _error(
+                "Binary has not been analyzed yet. Run analyze_binary first.",
+                binary_id=binary_id,
+                binary_path=path,
+                status="not_indexed",
+            )
+
+        payload = {
+            "binary_id": binary_id,
+            "binary_path": record.get("binary_path"),
+            "module_name": record.get("module_name"),
+            "image_base": record.get("image_base"),
+            "scope_description": record.get("scope_description"),
+            "scope_version": record.get("scope_version"),
+            "indexed_at": record.get("indexed_at"),
+            "status": "ready",
+        }
+        payload.update(store.counts(record))
+        return _json(payload)
+
+    @app.tool()
+    def mark_function_reviewed(
+        functions: str,
+        binary_id: str | None = None,
+        binary_path: str | None = None,
+        note: str | None = None,
+        reviewed: bool = True,
+    ) -> str:
+        """
+        Manually mark functions reviewed (or clear the mark).
+
+        The auto-mark side effect covers functions read through binary-mcp. Use
+        this for work done elsewhere -- a Ghidra GUI session, objdump,
+        a debugger -- and to attach a findings note to a reviewed function.
+
+        Args:
+            functions: Comma-separated addresses (``"0x140006d8c,140001010"``).
+                Addresses only -- names are ambiguous across a binary and the
+                ledger is keyed by address.
+            binary_id: Lowercase sha256 hexdigest of the binary's bytes.
+            binary_path: Optional path alternative to ``binary_id``.
+            note: Optional findings note stored against every listed function.
+            reviewed: Set False to clear the mark (e.g. a pass was retracted).
+
+        Returns:
+            JSON with ``marked`` / ``already`` / ``unknown`` address lists and
+            the refreshed counts. Marking is idempotent -- re-marking a
+            reviewed function does not double-count and does not overwrite its
+            original timestamp.
+        """
+        try:
+            resolved_id, resolved_path = _resolve(binary_id, binary_path)
+        except ValueError as exc:
+            return _error(str(exc))
+        except (PathTraversalError, FileSizeError, FileNotFoundError) as exc:
+            return _error(f"Invalid binary path: {exc}")
+
+        if not resolved_id:
+            return _error("No binary resolved. Pass binary_id or binary_path.")
+
+        requested = [item.strip() for item in (functions or "").split(",") if item.strip()]
+        if not requested:
+            return _error("No functions specified. Provide comma-separated addresses.")
+        if len(requested) > MAX_WORKLIST:
+            return _error(
+                f"Too many functions ({len(requested)}); maximum is {MAX_WORKLIST} per call."
+            )
+
+        malformed = [item for item in requested if not canon_addr(item)]
+        if malformed:
+            return _error(
+                "Not valid hex addresses: " + ", ".join(malformed[:5]),
+                hint="Pass addresses like 0x140006d8c, not function names.",
+            )
+
+        try:
+            record, status = store.ensure_indexed(resolved_id, resolved_path)
+            if record is None:
+                return _error(
+                    "Binary has not been analyzed yet. Run analyze_binary first.",
+                    binary_id=resolved_id,
+                    status=status,
+                )
+            result = store.mark_reviewed(
+                resolved_id, requested, tool="mark_function_reviewed",
+                note=note, reviewed=reviewed,
+            )
+            refreshed = store.read(resolved_id) or record
+        except Exception as exc:
+            logger.exception("mark_function_reviewed failed")
+            return _error(f"Mark failed: {exc}")
+
+        payload = {"binary_id": resolved_id, "status": status, **result}
+        payload.update(store.counts(refreshed))
+        return _json(payload)
+
+    logger.info("Registered 4 coverage tools")

--- a/src/tools/function_hash_tools.py
+++ b/src/tools/function_hash_tools.py
@@ -13,6 +13,8 @@ import logging
 import re
 from pathlib import Path
 
+from src.engines.static.ghidra.coverage_store import auto_mark
+
 logger = logging.getLogger(__name__)
 
 # Maximum functions per batch decompile request
@@ -467,6 +469,9 @@ def register_function_hash_tools(app, session_manager, cache, runner):
 
             succeeded = 0
             failed = 0
+            # Only functions whose pseudocode actually came back get marked --
+            # a "not found" or "thunk, no pseudocode" line reviewed nothing.
+            decompiled: list[str] = []
 
             for func_ref in requested:
                 func = _lookup_function(all_functions, func_ref)
@@ -491,6 +496,7 @@ def register_function_hash_tools(app, session_manager, cache, runner):
                     output.append("")
                     output.append(pseudocode)
                     succeeded += 1
+                    decompiled.append(address)
                 elif func.get("is_thunk"):
                     output.append("(thunk function - no pseudocode)")
                     failed += 1
@@ -505,6 +511,11 @@ def register_function_hash_tools(app, session_manager, cache, runner):
                 output.append("")
 
             output.append(f"Summary: {succeeded} succeeded, {failed} failed")
+
+            auto_mark(
+                cache, binary_path, decompiled,
+                tool="batch_decompile", context=cached,
+            )
 
             return "\n".join(output)
 

--- a/src/tools/function_hash_tools.py
+++ b/src/tools/function_hash_tools.py
@@ -13,7 +13,7 @@ import logging
 import re
 from pathlib import Path
 
-from src.engines.static.ghidra.coverage_store import auto_mark
+from src.engines.static.ghidra.coverage_store import auto_mark, has_reviewable_body
 
 logger = logging.getLogger(__name__)
 
@@ -496,7 +496,11 @@ def register_function_hash_tools(app, session_manager, cache, runner):
                     output.append("")
                     output.append(pseudocode)
                     succeeded += 1
-                    decompiled.append(address)
+                    # Printed either way -- a banner-comment-only body is still
+                    # worth showing -- but only actual code advances the
+                    # denominator.
+                    if has_reviewable_body(pseudocode):
+                        decompiled.append(address)
                 elif func.get("is_thunk"):
                     output.append("(thunk function - no pseudocode)")
                     failed += 1

--- a/src/tools/review_tools.py
+++ b/src/tools/review_tools.py
@@ -716,14 +716,19 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
             if not target:
                 return f"Function not found: {function_name_or_address}."
 
-            # Coverage side effect: a review package is the full-context read
-            # of one function, so it counts as reviewed.
-            auto_mark(
-                cache, binary_path, [target.get("address")],
-                tool="get_review_package", context=context,
-            )
-
             pseudo = target.get("pseudocode") or ""
+
+            # Coverage side effect: a review package is the full-context read of
+            # one function, so it counts as reviewed -- but ONLY once pseudocode
+            # is confirmed present. The package is still returned without it
+            # (callers, blocks and xrefs remain useful), yet a body nobody can
+            # read was not reviewed. Marking here regardless would drive a
+            # structural-depth cache to remaining==0 having shown zero code.
+            if pseudo.strip():
+                auto_mark(
+                    cache, binary_path, [target.get("address")],
+                    tool="get_review_package", context=context,
+                )
             signature = target.get("signature") or ""
             params = target.get("parameters") or []
             locals_ = target.get("local_variables") or []

--- a/src/tools/review_tools.py
+++ b/src/tools/review_tools.py
@@ -13,6 +13,7 @@ import logging
 import re
 from pathlib import Path
 
+from src.engines.static.ghidra.coverage_store import auto_mark
 from src.utils.pseudocode_rules import (
     SINK_HINTS,
     PseudocodeRules,
@@ -715,6 +716,13 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
             if not target:
                 return f"Function not found: {function_name_or_address}."
 
+            # Coverage side effect: a review package is the full-context read
+            # of one function, so it counts as reviewed.
+            auto_mark(
+                cache, binary_path, [target.get("address")],
+                tool="get_review_package", context=context,
+            )
+
             pseudo = target.get("pseudocode") or ""
             signature = target.get("signature") or ""
             params = target.get("parameters") or []
@@ -1003,6 +1011,14 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
                     f"has no pseudocode in the cache. Re-analyze with full "
                     f"decompilation enabled."
                 )
+
+            # Coverage side effect: a sink trace is a semantic per-function
+            # analysis, so the function counts as reviewed. Marked only once
+            # pseudocode is confirmed present -- a cache miss reviewed nothing.
+            auto_mark(
+                cache, binary_path, [target.get("address")],
+                tool="get_param_sinks", context=context,
+            )
 
             param_names = _collect_param_names(target)
             if not param_names:

--- a/src/tools/review_tools.py
+++ b/src/tools/review_tools.py
@@ -13,7 +13,7 @@ import logging
 import re
 from pathlib import Path
 
-from src.engines.static.ghidra.coverage_store import auto_mark
+from src.engines.static.ghidra.coverage_store import auto_mark, has_reviewable_body
 from src.utils.pseudocode_rules import (
     SINK_HINTS,
     PseudocodeRules,
@@ -724,7 +724,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
             # (callers, blocks and xrefs remain useful), yet a body nobody can
             # read was not reviewed. Marking here regardless would drive a
             # structural-depth cache to remaining==0 having shown zero code.
-            if pseudo.strip():
+            if has_reviewable_body(pseudo):
                 auto_mark(
                     cache, binary_path, [target.get("address")],
                     tool="get_review_package", context=context,
@@ -1010,7 +1010,7 @@ def register_review_tools(app, session_manager, cache, runner, api_patterns=None
                 )
 
             pseudo = target.get("pseudocode") or ""
-            if not pseudo.strip():
+            if not has_reviewable_body(pseudo):
                 return (
                     f"Function {target.get('name')} @ {target.get('address')} "
                     f"has no pseudocode in the cache. Re-analyze with full "

--- a/tests/test_coverage_store.py
+++ b/tests/test_coverage_store.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.engines.static.ghidra.coverage_store import (
+    SCHEMA_VERSION,
     SCOPE_VERSION,
     CoverageError,
     CoverageStore,
@@ -28,6 +29,7 @@ from src.engines.static.ghidra.coverage_store import (
     auto_mark,
     canon_addr,
     compute_scope,
+    has_reviewable_body,
 )
 from src.engines.static.ghidra.project_cache import ProjectCache
 
@@ -619,3 +621,286 @@ class TestAutoMark:
     def test_auto_mark_on_unanalyzed_binary_is_a_noop(self, lab):
         auto_mark(lab.cache, lab.path, ["140001000"], tool="decompile_function")
         assert lab.store.read(lab.binary_id) is None
+
+
+# Unparseable addresses and the drop accounting
+
+
+class TestDroppedAddresses:
+    """Functions whose address `canon_addr` rejects are absent from `total`.
+
+    `total` is derived from the normalized map; `source_function_count` comes
+    from the pre-normalization list. Nothing used to compare them, and both
+    staleness probes agreed with each other, so a denominator that had silently
+    lost functions was served as `ready` indefinitely.
+    """
+
+    def test_all_addresses_unparseable_is_not_indexed_not_six_zeros(self, lab):
+        """`ready` with `total: 0` is the documented terminal condition.
+
+        Reporting it for a binary whose every address failed to parse tells a
+        review loop it has finished a binary nobody read.
+        """
+        lab.analyze(
+            _context([_func("a", "EXTERNAL:1"), _func("b", "EXTERNAL:2")])
+        )
+        assert lab.store.index(lab.binary_id, lab.path) is None
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert record is None
+        assert status == "not_indexed"
+
+    def test_partial_drop_is_recorded_not_silent(self, lab):
+        lab.analyze(
+            _context(
+                [
+                    _func("a", "140001000"),
+                    _func("b", "140002000"),
+                    _func("x", "EXTERNAL:1"),
+                    _func("y", "EXTERNAL:2"),
+                    _func("z", "EXTERNAL:3"),
+                ]
+            )
+        )
+        record = lab.store.index(lab.binary_id, lab.path)
+        assert lab.store.counts(record)["total"] == 2
+        assert record["dropped_address_count"] == 3
+        assert record["source_function_count"] == 5
+        assert "under-counts" in record["scope_description"]
+
+    def test_clean_binary_records_a_zero_drop(self, lab):
+        """The field must be present and 0, not absent -- absent cannot be told
+        apart from 'nobody counted'."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        record = lab.store.index(lab.binary_id, lab.path)
+        assert record["dropped_address_count"] == 0
+
+    def test_counts_cross_check_catches_a_shrunken_denominator(self, lab):
+        """The one invariant that is not a restatement of its own arithmetic.
+
+        `source_function_count` was recorded from the analysis cache's function
+        list, so comparing the denominator against it detects a `total` that
+        lost functions -- which the remaining/total/reviewed relations cannot.
+        """
+        lab.analyze(_context([_func("a", "140001000"), _func("b", "140002000")]))
+        record = lab.store.index(lab.binary_id, lab.path)
+        del record["functions"]["0x140002000"]
+        with pytest.raises(CoverageError, match="does not account for every function"):
+            lab.store.counts(record)
+
+    def test_a_record_whose_numbers_do_not_add_up_is_rebuilt(self, lab):
+        """Corrupts only `dropped_address_count`, so `source_function_count`
+        still matches the meta side-car and the pre-existing count/scope/schema
+        triggers all pass. The arithmetic cross-check is the only thing that can
+        catch it."""
+        lab.analyze(_context([_func("a", "140001000"), _func("b", "140002000")]))
+        lab.store.index(lab.binary_id, lab.path)
+
+        stored = lab.store.read(lab.binary_id)
+        stored["dropped_address_count"] = 5
+        assert lab.store._source_function_count(lab.binary_id) == stored[
+            "source_function_count"
+        ], "the count trigger must NOT be what fires here"
+        lab.store.write(stored)
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert record["dropped_address_count"] == 0
+        assert lab.store.counts(record)["total"] == 2
+
+    def test_a_genuine_drop_does_not_rebuild_on_every_query(self, lab):
+        """`dropped != 0` must NOT be the rebuild trigger.
+
+        A binary that really does carry unparseable addresses would then
+        re-index -- decompressing the whole analysis cache -- on every status
+        poll forever, producing the identical record each time.
+        """
+        lab.analyze(_context([_func("a", "140001000"), _func("x", "EXTERNAL:1")]))
+        first, _ = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        second, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert second["indexed_at"] == first["indexed_at"]
+
+
+# On-disk schema versioning
+
+
+class TestSchemaVersion:
+    """`schema_version` was written but never read: a record stamped 999 was
+    accepted and served as `ready`."""
+
+    def _corrupt(self, lab, **fields):
+        stored = lab.store.read(lab.binary_id)
+        stored.update(fields)
+        path = lab.cache.cache_dir / f"{lab.binary_id}.coverage.json"
+        path.write_text(json.dumps(stored), encoding="utf-8")
+
+    @pytest.mark.parametrize("version", [999, "2", None, True])
+    def test_unreadable_schema_version_is_refused(self, lab, version):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        self._corrupt(lab, schema_version=version)
+        assert lab.store.read(lab.binary_id) is None
+
+    def test_a_future_record_reports_not_indexed_not_ready(self, lab):
+        """Null counts are the honest answer for a layout we cannot interpret;
+        serving it as `ready` puts numbers of unknown provenance in front of a
+        closure decision."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        self._corrupt(lab, schema_version=999)
+        # Remove the rebuild source so the refusal is what decides the status,
+        # rather than an immediate re-index papering over it.
+        (lab.cache.cache_dir / f"{lab.binary_id}.json.gz").unlink()
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert record is None
+        assert status == "not_indexed"
+
+    def test_an_older_readable_record_is_rebuilt_with_marks_intact(self, lab):
+        """A v1 record has a readable layout, so its review history is
+        salvageable -- rebuild, do not discard."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a", note="keep")
+        stored = lab.store.read(lab.binary_id)
+        stored["schema_version"] = 1
+        del stored["dropped_address_count"]
+        lab.store.write(stored)
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert record["schema_version"] == SCHEMA_VERSION
+        assert record["dropped_address_count"] == 0
+        entry = record["functions"]["0x140001000"]
+        assert entry["reviewed"] is True
+        assert entry["findings_note"] == "keep"
+
+    def test_a_future_scope_version_is_rebuilt_under_current_semantics(self, lab):
+        """Documented downgrade behaviour: any scope_version mismatch rebuilds,
+        future included, and re-stamps the record with the current string. The
+        consumer detects it by reading `scope_version` back."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        stored = lab.store.read(lab.binary_id)
+        stored["scope_version"] = "fwd-bfs-v99"
+        lab.store.write(stored)
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert record["scope_version"] == SCOPE_VERSION
+
+
+# What `in_scope` actually means
+
+
+class TestScopeIsProvenanceNotFiltering:
+    """The fixpoint drains the residual entirely, so membership is exactly
+    "not mechanically excluded" and the walk only supplies `scope_reason`.
+
+    Documenting it the other way round -- "in_scope is real reachability" --
+    invites a consumer to believe the call graph narrowed the denominator.
+    """
+
+    def test_in_scope_is_total_minus_the_mechanical_exclusions(self, lab):
+        lab.analyze(
+            _context(
+                [
+                    _func("entry", "140001000"),
+                    _func("thunk", "140002000", is_thunk=True),
+                    _func("ext", "140003000", is_external=True),
+                    _func("fid", "140004000", fid_match="memcpy"),
+                    # Reachable only through a cycle nothing calls into.
+                    _func("cyc_a", "140005000", called=["140006000"]),
+                    _func("cyc_b", "140006000", called=["140005000"]),
+                ]
+            )
+        )
+        record = lab.store.index(lab.binary_id, lab.path)
+        counts = lab.store.counts(record)
+        excluded = sum(
+            1
+            for e in record["functions"].values()
+            if e["scope_reason"].startswith("excluded:")
+        )
+        assert excluded == 3
+        assert counts["in_scope_total"] == counts["total"] - excluded
+
+    def test_nothing_is_ever_labelled_excluded_unreachable(self, lab):
+        lab.analyze(
+            _context(
+                [
+                    _func("cyc_a", "140005000", called=["140006000"]),
+                    _func("cyc_b", "140006000", called=["140005000"]),
+                    _func("below", "140007000"),
+                ]
+            )
+        )
+        record = lab.store.index(lab.binary_id, lab.path)
+        reasons = {e["scope_reason"] for e in record["functions"].values()}
+        assert "excluded:unreachable" not in reasons
+
+    def test_disjoint_cycles_are_promoted_in_one_pass(self):
+        """Guards the fixpoint against going quadratic again.
+
+        Each pass recomputes `residual` and `called_within` over the whole
+        graph. Promoting one root per pass therefore costs one full sweep per
+        independent cycle -- and every fixpoint pass on the real cached corpus
+        is a no-source pass, so this is the path real binaries take, not a
+        synthetic corner. Counting `canon_addr` calls measures it without a
+        wall clock: linear here, quadratic before (800 nodes: 3200 vs 162800).
+        """
+        import src.engines.static.ghidra.coverage_store as module
+
+        nodes = 800
+        functions = []
+        for i in range(0, nodes, 2):
+            a = 0x140001000 + i * 0x10
+            b = a + 0x10
+            functions.append(_func(f"f{a:x}", f"{a:x}", called=[f"{b:x}"]))
+            functions.append(_func(f"f{b:x}", f"{b:x}", called=[f"{a:x}"]))
+
+        real = module.canon_addr
+        calls = []
+
+        def counting(raw):
+            calls.append(1)
+            return real(raw)
+
+        module.canon_addr = counting
+        try:
+            records, _description = module.compute_scope(_context(functions))
+        finally:
+            module.canon_addr = real
+
+        assert len(records) == nodes
+        assert all(r["in_scope"] for r in records.values())
+        assert len(calls) < 10 * nodes, (
+            f"{len(calls)} canon_addr calls for {nodes} nodes -- the fixpoint is "
+            f"promoting one root per pass again"
+        )
+
+
+# The reviewable-body predicate
+
+
+class TestHasReviewableBody:
+    """Auto-marking must not advance the denominator for a function whose code
+    nobody saw. Ghidra emits banner-comment-only bodies when it declines to
+    decompile, and non-empty alone accepts those."""
+
+    def test_comment_only_body_is_not_a_review(self):
+        assert not has_reviewable_body(
+            "/* WARNING: Globals starting with '_' overlap smaller symbols */\n"
+        )
+
+    def test_genuine_empty_stub_still_marks(self):
+        """http.sys FUN_140137c58 and FUN_1401d5530, verbatim. These are real,
+        reviewable code -- excluding them would under-mark."""
+        assert has_reviewable_body("void FUN_140137c58(void)\n\n{\n  return;\n}")
+
+    def test_ordinary_body_marks(self):
+        assert has_reviewable_body("int f(void) { return g(1); }")
+
+    def test_empty_and_non_string_do_not_mark(self):
+        assert not has_reviewable_body("")
+        assert not has_reviewable_body("   \n ")
+        assert not has_reviewable_body(None)

--- a/tests/test_coverage_store.py
+++ b/tests/test_coverage_store.py
@@ -473,6 +473,49 @@ class TestIndexing:
         assert status == "ready"
         assert record["scope_version"] == SCOPE_VERSION
 
+    def test_a_v1_record_is_rebuilt_and_its_shrunken_scope_repaired(self, lab):
+        """The scope fix is worthless on existing records without the bump.
+
+        `scope_version` IS the rebuild trigger. A record written under
+        `fwd-bfs-v1` carries that version's shrunken scope -- a cycle reached
+        only indirectly, and everything below it, flagged out. If the constant
+        had stayed at v1 the mismatch would never fire and the shrink would be
+        permanent on every already-indexed binary.
+        """
+        ctx = _context(
+            [
+                _func("entry", "140001000"),
+                _func("DoCollect", "140002000", called=["140003000"]),
+                _func("FinishConcurrent", "140003000",
+                      called=["140002000", "140004000"]),
+                _func("MarkInterior", "140004000"),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        lab.analyze(ctx)
+        lab.store.index(lab.binary_id, lab.path)
+
+        # Rewind to what v1 would have written: the cycle and its subtree out
+        # of scope, stamped with the version that produced it.
+        stored = lab.store.read(lab.binary_id)
+        stored["scope_version"] = "fwd-bfs-v1"
+        for addr in ("0x140002000", "0x140003000", "0x140004000"):
+            stored["functions"][addr]["in_scope"] = False
+            stored["functions"][addr]["scope_reason"] = "excluded:unreachable"
+        # A mark taken under v1 must survive the migration.
+        stored["functions"]["0x140001000"]["reviewed"] = True
+        stored["functions"]["0x140001000"]["reviewed_at"] = "2026-08-03T12:00:00Z"
+        stored["functions"]["0x140001000"]["reviewed_by"] = "decompile_function"
+        lab.store.write(stored)
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert record["scope_version"] == SCOPE_VERSION
+        assert lab.store.counts(record)["in_scope_total"] == 4
+        assert record["functions"]["0x140004000"]["in_scope"]
+        assert record["functions"]["0x140001000"]["reviewed"] is True
+        assert record["functions"]["0x140001000"]["reviewed_at"] == "2026-08-03T12:00:00Z"
+
     def test_missing_analysis_cache_reports_stale_not_ready(self, lab):
         lab.analyze(_context([_func("entry", "140001000")]))
         lab.store.index(lab.binary_id, lab.path)

--- a/tests/test_coverage_store.py
+++ b/tests/test_coverage_store.py
@@ -1,0 +1,533 @@
+"""
+Tests for the per-binary review-coverage store.
+
+Covers:
+- Address canonicalization (the cross-process function key).
+- Forward-BFS scope: export / dispatch / address-taken roots, callee
+  propagation, and the mechanical exclusions.
+- The six counts and the invariants a consumer asserts on.
+- Cold start: an unindexed binary reports null counts, never zero.
+- Deterministic worklist ordering and forward progress.
+- Auto-mark idempotency and the tools that must NOT auto-mark.
+- Side-car lifecycle against ProjectCache.invalidate / clear_all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.engines.static.ghidra.coverage_store import (
+    SCOPE_VERSION,
+    CoverageError,
+    CoverageStore,
+    _assert_invariants,
+    auto_mark,
+    canon_addr,
+    compute_scope,
+)
+from src.engines.static.ghidra.project_cache import ProjectCache
+
+# Fixtures / builders
+
+
+def _func(
+    name,
+    address,
+    called=None,
+    *,
+    is_thunk=False,
+    is_external=False,
+    decompile_status="success",
+    fid_match=None,
+    size=64,
+    parameters=None,
+    pseudocode="",
+    jump_tables=None,
+):
+    """Build a cached-function record in the shape core_analysis.py emits.
+
+    Note the bare, unprefixed address -- that is what Ghidra actually writes,
+    and normalizing it is the store's job.
+    """
+    return {
+        "name": name,
+        "address": address,
+        "size": size,
+        "is_thunk": is_thunk,
+        "is_external": is_external,
+        "decompile_status": decompile_status,
+        "fid_match": fid_match,
+        "parameters": parameters or [],
+        "pseudocode": pseudocode,
+        "jump_tables": jump_tables or [],
+        "called_functions": [{"address": a, "name": ""} for a in (called or [])],
+    }
+
+
+def _context(functions, exports=None, image_base="140000000", name="test.sys"):
+    return {
+        "metadata": {
+            "name": name,
+            "image_base": image_base,
+            "analysis_depth": "full",
+            "executable_path": f"/tmp/{name}",
+        },
+        "functions": functions,
+        "exports": exports or [],
+    }
+
+
+@pytest.fixture
+def lab(tmp_path):
+    """A real ProjectCache over tmp_path plus a real binary file.
+
+    Coverage is a disk side-car keyed off a content hash, so the round-trip is
+    the thing worth testing; mocking the cache would test nothing.
+    """
+
+    class Lab:
+        def __init__(self):
+            self.cache = ProjectCache(cache_dir=str(tmp_path))
+            self.store = CoverageStore(self.cache)
+            self.binary = tmp_path / "test.sys"
+            self.binary.write_bytes(b"MZ" + b"\x00" * 512)
+            self.path = str(self.binary)
+            self.binary_id = hashlib.sha256(self.binary.read_bytes()).hexdigest()
+
+        def analyze(self, context):
+            self.cache.save_cached(self.path, context)
+            return context
+
+    return Lab()
+
+
+# Address canonicalization
+
+
+class TestCanonAddr:
+    def test_bare_hex_gains_prefix(self):
+        assert canon_addr("140006d8c") == "0x140006d8c"
+
+    def test_prefixed_passes_through(self):
+        assert canon_addr("0x140006d8c") == "0x140006d8c"
+
+    def test_uppercase_is_lowered(self):
+        assert canon_addr("0x140006D8C") == "0x140006d8c"
+
+    def test_zero_padding_is_stripped(self):
+        assert canon_addr("0x0000000140006d8c") == "0x140006d8c"
+
+    def test_int_is_accepted(self):
+        assert canon_addr(0x140006D8C) == "0x140006d8c"
+
+    def test_external_pseudo_address_is_dropped(self):
+        assert canon_addr("EXTERNAL:0000005b") == ""
+
+    def test_garbage_is_dropped(self):
+        assert canon_addr("FUN_140006d8c") == ""
+        assert canon_addr(None) == ""
+        assert canon_addr("") == ""
+
+    def test_output_survives_notes_mcp_normalization(self):
+        """notes-mcp emits f"0x{int(body,16):x}"; a naive compare must match."""
+        for raw in ("140006d8c", "0x140006D8C", "0x0000000140006d8c", 0x140006D8C):
+            canon = canon_addr(raw)
+            body = canon[2:]
+            assert f"0x{int(body, 16):x}" == canon
+
+
+# Scope computation
+
+
+class TestComputeScope:
+    def test_export_root_and_callee_propagation(self):
+        ctx = _context(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                _func("helper", "140002000"),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _desc = compute_scope(ctx)
+        assert records["0x140001000"]["scope_reason"] == "reachable:export"
+        assert records["0x140002000"]["scope_reason"] == "reachable:callee"
+        assert all(r["in_scope"] for r in records.values())
+
+    def test_address_taken_function_is_a_root(self):
+        """A registered callback has no direct caller; it must stay in scope.
+
+        Under-counting scope is the dangerous direction -- it shrinks the
+        denominator and manufactures false completion.
+        """
+        ctx = _context(
+            [
+                _func("entry", "140001000"),
+                _func("BfPreClose", "140002000", called=["140003000"]),
+                _func("deep", "140003000"),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert records["0x140002000"]["scope_reason"] == "reachable:indirect_root"
+        assert records["0x140003000"]["scope_reason"] == "reachable:callee"
+        assert records["0x140003000"]["in_scope"]
+
+    def test_dispatcher_candidate_is_an_entry_point(self):
+        ctx = _context(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                _func(
+                    "DriverDispatch",
+                    "140002000",
+                    parameters=[{"name": "param_1", "datatype": "PIRP"}],
+                ),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert records["0x140002000"]["scope_reason"] == "reachable:ioctl_dispatch"
+
+    def test_switch_table_targets_are_entry_points(self):
+        ctx = _context(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                _func(
+                    "DriverDispatch",
+                    "140002000",
+                    parameters=[{"name": "param_1", "datatype": "PIRP"}],
+                    jump_tables=[{"source_addr": "140002010", "targets": ["140004000"]}],
+                ),
+                # Reached only through the jump table, and it has a caller
+                # recorded nowhere -- without the table join it would still be
+                # an indirect_root, so give it one to prove the join fires.
+                _func("handler", "140004000"),
+                _func("caller_of_handler", "140005000", called=["140004000"]),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert records["0x140004000"]["scope_reason"] == "reachable:ioctl_dispatch"
+
+    @pytest.mark.parametrize(
+        "kwargs,reason",
+        [
+            ({"is_thunk": True}, "excluded:thunk"),
+            ({"is_external": True}, "excluded:external"),
+            (
+                {"decompile_status": "skipped_thunk_or_external"},
+                "excluded:thunk_or_external",
+            ),
+            ({"fid_match": {"library": "vs2019"}}, "excluded:fid_library"),
+        ],
+    )
+    def test_mechanical_exclusions(self, kwargs, reason):
+        ctx = _context(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                _func("lib", "140002000", **kwargs),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert records["0x140002000"]["in_scope"] is False
+        assert records["0x140002000"]["scope_reason"] == reason
+
+    def test_excluded_functions_remain_in_the_map(self):
+        """scope='all' must still reach them -- an invisible function is work
+        that silently disappeared from the ledger."""
+        ctx = _context(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                _func("thunk", "140002000", is_thunk=True),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert "0x140002000" in records
+
+    def test_external_callee_addresses_do_not_create_phantom_functions(self):
+        ctx = _context(
+            [_func("entry", "140001000", called=["EXTERNAL:00000055"])],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert list(records) == ["0x140001000"]
+
+    def test_scope_description_records_the_method(self):
+        ctx = _context([_func("entry", "140001000")])
+        _records, desc = compute_scope(ctx)
+        assert "forward BFS" in desc
+        assert "Indirect calls are invisible" in desc
+
+
+# Counts and invariants
+
+
+class TestCounts:
+    def test_counts_derive_from_the_function_map(self, lab):
+        lab.analyze(
+            _context(
+                [
+                    _func("entry", "140001000", called=["140002000"]),
+                    _func("helper", "140002000"),
+                    _func("thunk", "140003000", is_thunk=True),
+                ],
+                exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+            )
+        )
+        record = lab.store.index(lab.binary_id, lab.path)
+        counts = lab.store.counts(record)
+        assert counts == {
+            "total": 3,
+            "in_scope_total": 2,
+            "reviewed": 0,
+            "reviewed_in_scope": 0,
+            "remaining": 3,
+            "remaining_in_scope": 2,
+        }
+
+    def test_reviewed_in_scope_tracks_scope(self, lab):
+        lab.analyze(
+            _context(
+                [
+                    _func("entry", "140001000"),
+                    _func("thunk", "140002000", is_thunk=True),
+                ]
+            )
+        )
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(lab.binary_id, ["0x140002000"], tool="t")
+        counts = lab.store.counts(lab.store.read(lab.binary_id))
+        assert counts["reviewed"] == 1
+        assert counts["reviewed_in_scope"] == 0
+        assert counts["remaining_in_scope"] == 1
+
+    @pytest.mark.parametrize(
+        "counts",
+        [
+            {"total": 10, "in_scope_total": 5, "reviewed": 2, "reviewed_in_scope": 1,
+             "remaining": 7, "remaining_in_scope": 4},
+            {"total": 10, "in_scope_total": 5, "reviewed": 2, "reviewed_in_scope": 1,
+             "remaining": 8, "remaining_in_scope": 3},
+            {"total": 5, "in_scope_total": 9, "reviewed": 0, "reviewed_in_scope": 0,
+             "remaining": 5, "remaining_in_scope": 9},
+            {"total": 10, "in_scope_total": 5, "reviewed": 1, "reviewed_in_scope": 3,
+             "remaining": 9, "remaining_in_scope": 2},
+            {"total": -1, "in_scope_total": 0, "reviewed": 0, "reviewed_in_scope": 0,
+             "remaining": -1, "remaining_in_scope": 0},
+        ],
+    )
+    def test_invariant_violations_raise(self, counts):
+        with pytest.raises(CoverageError):
+            _assert_invariants(counts)
+
+
+# Marking
+
+
+class TestMarking:
+    def test_mark_is_idempotent(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+
+        first = lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a")
+        stamp = lab.store.read(lab.binary_id)["functions"]["0x140001000"]["reviewed_at"]
+        second = lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="b")
+
+        assert first["marked"] == ["0x140001000"]
+        assert second["marked"] == []
+        assert second["already"] == ["0x140001000"]
+        entry = lab.store.read(lab.binary_id)["functions"]["0x140001000"]
+        assert entry["reviewed_at"] == stamp
+        assert entry["reviewed_by"] == "a"
+        assert lab.store.counts(lab.store.read(lab.binary_id))["reviewed"] == 1
+
+    def test_unknown_address_never_inflates_the_count(self, lab):
+        """A phantom entry would push reviewed above total and break the
+        invariants the consumer asserts on."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+
+        result = lab.store.mark_reviewed(lab.binary_id, ["0xdeadbeef"], tool="a")
+        assert result["unknown"] == ["0xdeadbeef"]
+        counts = lab.store.counts(lab.store.read(lab.binary_id))
+        assert counts["reviewed"] == 0
+        assert counts["total"] == 1
+
+    def test_mark_accepts_any_address_spelling(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        result = lab.store.mark_reviewed(lab.binary_id, ["140001000"], tool="a")
+        assert result["marked"] == ["0x140001000"]
+
+    def test_unmark(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a")
+        lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a", reviewed=False)
+        assert lab.store.counts(lab.store.read(lab.binary_id))["reviewed"] == 0
+
+    def test_findings_note_is_stored(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(
+            lab.binary_id, ["0x140001000"], tool="a", note="unchecked length"
+        )
+        entry = lab.store.read(lab.binary_id)["functions"]["0x140001000"]
+        assert entry["findings_note"] == "unchecked length"
+
+
+# Indexing lifecycle
+
+
+class TestIndexing:
+    def test_reindex_preserves_review_marks(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a", note="keep me")
+        stamp = lab.store.read(lab.binary_id)["functions"]["0x140001000"]["reviewed_at"]
+
+        # An incremental Ghidra run grows the function list.
+        lab.analyze(
+            _context([_func("entry", "140001000"), _func("new", "140002000")])
+        )
+        record = lab.store.index(lab.binary_id, lab.path)
+
+        entry = record["functions"]["0x140001000"]
+        assert entry["reviewed"] is True
+        assert entry["reviewed_at"] == stamp
+        assert entry["findings_note"] == "keep me"
+        assert lab.store.counts(record)["total"] == 2
+        assert lab.store.counts(record)["reviewed"] == 1
+
+    def test_growing_analysis_cache_triggers_reindex(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert lab.store.counts(record)["total"] == 1
+
+        lab.analyze(
+            _context([_func("entry", "140001000"), _func("new", "140002000")])
+        )
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert lab.store.counts(record)["total"] == 2
+
+    def test_scope_version_bump_triggers_reindex(self, lab, monkeypatch):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+
+        stored = lab.store.read(lab.binary_id)
+        stored["scope_version"] = "stale-v0"
+        lab.store.write(stored)
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "ready"
+        assert record["scope_version"] == SCOPE_VERSION
+
+    def test_missing_analysis_cache_reports_stale_not_ready(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        (lab.cache.cache_dir / f"{lab.binary_id}.json.gz").unlink()
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, lab.path)
+        assert status == "stale"
+        assert lab.store.counts(record)["total"] == 1
+
+    def test_index_by_sha_works_without_the_file(self, lab):
+        """The ledger key outlives the staging tree; a consumer holding only a
+        sha must still be able to index."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.binary.unlink()
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, None)
+        assert status == "ready"
+        assert lab.store.counts(record)["total"] == 1
+
+    def test_legacy_uncompressed_cache_is_readable(self, lab):
+        ctx = _context([_func("entry", "140001000")])
+        gz = lab.cache.cache_dir / f"{lab.binary_id}.json.gz"
+        legacy = lab.cache.cache_dir / f"{lab.binary_id}.json"
+        legacy.write_text(json.dumps(ctx))
+        assert not gz.exists()
+
+        record, status = lab.store.ensure_indexed(lab.binary_id, None)
+        assert status == "ready"
+        assert lab.store.counts(record)["total"] == 1
+
+    def test_resolve_rejects_a_non_sha_binary_id(self, lab):
+        with pytest.raises(ValueError):
+            lab.store.resolve(binary_id="not-a-hash")
+
+    def test_image_base_is_canonicalized(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")], image_base="140000000"))
+        record = lab.store.index(lab.binary_id, lab.path)
+        assert record["image_base"] == "0x140000000"
+
+
+# Side-car lifecycle against the surrounding cache
+
+
+class TestSidecarLifecycle:
+    def test_coverage_survives_invalidate(self, lab):
+        """force_reanalyze must not destroy a review history: the key is a
+        content hash, so the addresses cannot have shifted."""
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.store.mark_reviewed(lab.binary_id, ["0x140001000"], tool="a")
+
+        lab.cache.invalidate(lab.path)
+
+        record = lab.store.read(lab.binary_id)
+        assert record is not None
+        assert record["functions"]["0x140001000"]["reviewed"] is True
+
+    def test_clear_all_drops_coverage(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        lab.cache.clear_all()
+        assert lab.store.read(lab.binary_id) is None
+
+    def test_legacy_prune_never_eats_the_sidecar(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        # Re-running the constructor triggers _prune_legacy_duplicates.
+        ProjectCache(cache_dir=str(lab.cache.cache_dir))
+        assert (lab.cache.cache_dir / f"{lab.binary_id}.coverage.json").exists()
+
+    def test_write_is_atomic_and_leaves_no_temp_files(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        lab.store.index(lab.binary_id, lab.path)
+        leftovers = list(lab.cache.cache_dir.glob("*.tmp"))
+        assert leftovers == []
+
+
+# auto_mark hook
+
+
+class TestAutoMark:
+    def test_auto_mark_indexes_then_marks(self, lab):
+        ctx = lab.analyze(_context([_func("entry", "140001000")]))
+        auto_mark(lab.cache, lab.path, ["140001000"], tool="decompile_function", context=ctx)
+        record = lab.store.read(lab.binary_id)
+        assert record["functions"]["0x140001000"]["reviewed"] is True
+        assert record["functions"]["0x140001000"]["reviewed_by"] == "decompile_function"
+
+    def test_auto_mark_never_raises(self, lab):
+        """Coverage is additive: a ledger failure must not break a decompile."""
+        broken = MagicMock()
+        broken.cache_dir = lab.cache.cache_dir
+        broken._get_binary_hash.side_effect = OSError("boom")
+        auto_mark(broken, lab.path, ["140001000"], tool="decompile_function")
+
+    def test_auto_mark_ignores_empty_input(self, lab):
+        lab.analyze(_context([_func("entry", "140001000")]))
+        auto_mark(lab.cache, lab.path, [], tool="decompile_function")
+        assert lab.store.read(lab.binary_id) is None
+
+    def test_auto_mark_on_unanalyzed_binary_is_a_noop(self, lab):
+        auto_mark(lab.cache, lab.path, ["140001000"], tool="decompile_function")
+        assert lab.store.read(lab.binary_id) is None

--- a/tests/test_coverage_store.py
+++ b/tests/test_coverage_store.py
@@ -157,6 +157,51 @@ class TestComputeScope:
         assert records["0x140002000"]["scope_reason"] == "reachable:callee"
         assert all(r["in_scope"] for r in records.values())
 
+    def test_cycle_reachable_subtree_stays_in_scope(self):
+        """A callback that recurses must not drop its whole subtree.
+
+        `reachable:indirect_root` means "no direct caller anywhere", and every
+        member of a call cycle has one -- so before the fixpoint promotion the
+        walk could not enter, and everything below fell out as
+        excluded:unreachable. On the real corpus that was silently dropping
+        http.sys parsers. Under-counting scope is the dangerous direction.
+        """
+        ctx = _context(
+            [
+                _func("entry", "140001000"),
+                # DoCollect <-> FinishConcurrent is a cycle reached only
+                # indirectly; MarkInterior hangs below it.
+                _func("DoCollect", "140002000", called=["140003000"]),
+                _func("FinishConcurrent", "140003000",
+                      called=["140002000", "140004000"]),
+                _func("MarkInterior", "140004000"),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, desc = compute_scope(ctx)
+        assert all(
+            r["scope_reason"] != "excluded:unreachable" for r in records.values()
+        ), records
+        assert records["0x140004000"]["in_scope"]
+        assert "unreachable from any root" not in desc
+
+    def test_self_recursive_root_still_in_scope(self):
+        """The one-line mutation that used to flip a root out of scope."""
+        ctx = _context(
+            [
+                _func("entry", "140001000"),
+                # Self-loop: has a direct caller (itself), so never an
+                # indirect_root under the old rule.
+                _func("BfPreClose", "140002000",
+                      called=["140002000", "140003000"]),
+                _func("deep", "140003000"),
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        records, _ = compute_scope(ctx)
+        assert records["0x140002000"]["in_scope"]
+        assert records["0x140003000"]["in_scope"]
+
     def test_address_taken_function_is_a_root(self):
         """A registered callback has no direct caller; it must stay in scope.
 

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -116,6 +116,7 @@ def tools(tmp_path):
             self.next = app.tools["get_next_unreviewed"]
             self.index = app.tools["coverage_index"]
             self.mark = app.tools["mark_function_reviewed"]
+            self.reset = app.tools["reset_coverage"]
 
         def analyze(self, functions, exports=None):
             self.cache.save_cached(self.path, _context(functions, exports))
@@ -402,6 +403,104 @@ class TestMarkTool:
     def test_mark_before_analysis_is_an_error(self, tools):
         payload = _payload(tools.mark(functions="0x140002000", binary_id=tools.binary_id))
         assert "error" in payload
+
+
+class TestResetTool:
+    """The undo for a contaminated ledger.
+
+    Marks that don't reflect anyone reading the code are worse than no marks:
+    the next campaign reads "fully reviewed" and stops. Operators need a
+    documented way to correct that without deleting files out of the cache.
+    """
+
+    def test_reset_clears_every_mark(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(
+            tools.binary_id, ["0x140001000", "0x140002000"], tool="t", note="bogus"
+        )
+        assert tools.store.counts(tools.store.read(tools.binary_id))["reviewed"] == 2
+
+        payload = _payload(tools.reset(binary_id=tools.binary_id))
+
+        assert payload["cleared"] == 2
+        assert payload["reviewed"] == 0
+        assert payload["reviewed_in_scope"] == 0
+        assert payload["remaining"] == payload["total"]
+        _assert_contract_invariants(payload)
+
+    def test_reset_clears_findings_notes_too(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(
+            tools.binary_id, ["0x140002000"], tool="t", note="bogus finding"
+        )
+        tools.reset(binary_id=tools.binary_id)
+        entry = tools.store.read(tools.binary_id)["functions"]["0x140002000"]
+        assert entry["findings_note"] is None
+        assert entry["reviewed_at"] is None
+        assert entry["reviewed_by"] is None
+
+    def test_reset_keeps_the_index_and_scope(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        payload = _payload(tools.reset(binary_id=tools.binary_id))
+        assert payload["status"] == "ready"
+        assert payload["total"] == 3
+        assert payload["in_scope_total"] == 2
+        assert payload["dropped"] is False
+
+    def test_reset_is_idempotent(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        tools.reset(binary_id=tools.binary_id)
+        payload = _payload(tools.reset(binary_id=tools.binary_id))
+        assert payload["cleared"] == 0
+        assert payload["reviewed"] == 0
+
+    def test_drop_index_rebuilds_from_the_analysis_cache(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        payload = _payload(tools.reset(binary_id=tools.binary_id, drop_index=True))
+        assert payload["dropped"] is True
+        assert payload["status"] == "ready"
+        assert payload["total"] == 3
+        assert payload["reviewed"] == 0
+
+    def test_reset_without_a_record_is_an_error_not_a_silent_success(self, tools):
+        tools.three_functions()
+        payload = _payload(tools.reset(binary_id=tools.binary_id))
+        assert "error" in payload
+        assert payload["status"] == "not_indexed"
+
+    def test_reset_by_path(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        payload = _payload(tools.reset(binary_path=tools.path))
+        assert payload["cleared"] == 1
+
+    def test_reset_does_not_touch_the_analysis_cache(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.reset(binary_id=tools.binary_id, drop_index=True)
+        assert (tools.cache.cache_dir / f"{tools.binary_id}.json.gz").exists()
+
+    def test_worklist_is_full_again_after_a_reset(self, tools):
+        """The point of the reset: the loop must have work to do again."""
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(
+            tools.binary_id, ["0x140001000", "0x140002000"], tool="t"
+        )
+        assert _payload(tools.next(binary_id=tools.binary_id))["functions"] == []
+        tools.reset(binary_id=tools.binary_id)
+        after = _payload(tools.next(binary_id=tools.binary_id))
+        assert len(after["functions"]) == 2
+        assert after["remaining_after"] == 0
 
 
 class TestAutoMarkingSet:

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -72,6 +72,15 @@ def _context(functions, exports=None):
     }
 
 
+def _payload(result):
+    """Tools return a plain dict; FastMCP serializes it at the boundary.
+
+    Accepting either shape keeps these assertions honest whichever side of the
+    protocol they are read from.
+    """
+    return json.loads(result) if isinstance(result, str) else result
+
+
 class _App:
     """Minimal FastMCP stand-in that captures the registered callables."""
 
@@ -137,24 +146,49 @@ def _assert_contract_invariants(payload):
     assert payload["reviewed_in_scope"] <= payload["reviewed"]
 
 
+class TestWireShape:
+    """The tools must return a dict, not a JSON string.
+
+    FastMCP puts a ``str`` return under ``structuredContent.result`` *as a
+    string*, so a consumer that peels one envelope layer lands on a string and
+    its flat-object assumption breaks. Returning the object itself keeps every
+    transport path flat.
+    """
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda t: t.status(binary_id="f" * 64),
+            lambda t: t.next(binary_id="f" * 64),
+            lambda t: t.index(binary_path=t.path),
+            lambda t: t.mark(functions="0x1", binary_id="f" * 64),
+        ],
+    )
+    def test_tools_return_flat_objects(self, tools, call):
+        result = call(tools)
+        assert isinstance(result, dict), f"got {type(result).__name__}"
+        assert "result" not in result
+        assert "data" not in result
+
+
 class TestColdStart:
     def test_unindexed_binary_returns_null_counts_not_zero(self, tools):
         """Zero here reads as 'complete' and would terminate a review loop on a
         binary nobody has looked at -- the exact bug this store exists to fix.
         """
-        payload = json.loads(tools.status(binary_id="f" * 64))
+        payload = _payload(tools.status(binary_id="f" * 64))
         assert payload["status"] == "not_indexed"
         for field in COUNT_FIELDS:
             assert payload[field] is None, f"{field} must be null, got {payload[field]!r}"
 
     def test_unindexed_response_is_still_well_formed(self, tools):
-        payload = json.loads(tools.status(binary_id="f" * 64))
+        payload = _payload(tools.status(binary_id="f" * 64))
         assert STATUS_FIELDS <= set(payload)
         assert payload["binary_id"] == "f" * 64
         assert payload["scope_version"] == SCOPE_VERSION
 
     def test_worklist_on_unindexed_binary_is_not_terminal(self, tools):
-        payload = json.loads(tools.next(binary_id="f" * 64))
+        payload = _payload(tools.next(binary_id="f" * 64))
         assert payload["status"] == "not_indexed"
         assert payload["functions"] == []
         assert payload["remaining_after"] is None
@@ -163,7 +197,7 @@ class TestColdStart:
         """Reporting not_indexed for a binary that is already fully analyzed
         would strand every previously-cached target."""
         tools.three_functions()
-        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        payload = _payload(tools.status(binary_id=tools.binary_id))
         assert payload["status"] == "ready"
         assert payload["total"] == 3
 
@@ -171,7 +205,7 @@ class TestColdStart:
 class TestStatusShape:
     def test_field_names_and_invariants(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        payload = _payload(tools.status(binary_id=tools.binary_id))
         assert STATUS_FIELDS <= set(payload)
         _assert_contract_invariants(payload)
         assert payload["total"] == 3
@@ -182,39 +216,39 @@ class TestStatusShape:
 
     def test_image_base_is_prefixed_hex(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        payload = _payload(tools.status(binary_id=tools.binary_id))
         assert payload["image_base"] == "0x140000000"
 
     def test_scope_version_is_reported(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        payload = _payload(tools.status(binary_id=tools.binary_id))
         assert payload["scope_version"] == SCOPE_VERSION
 
     def test_binary_path_resolution(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.status(binary_path=tools.path))
+        payload = _payload(tools.status(binary_path=tools.path))
         assert payload["binary_id"] == tools.binary_id
         assert payload["status"] == "ready"
 
     def test_active_session_binary_is_the_fallback(self, tools):
         tools.three_functions()
         tools.sessions._current_binary_path = tools.path
-        payload = json.loads(tools.status())
+        payload = _payload(tools.status())
         assert payload["binary_id"] == tools.binary_id
 
     def test_no_resolvable_binary_is_an_error(self, tools):
-        payload = json.loads(tools.status())
+        payload = _payload(tools.status())
         assert "error" in payload
 
     def test_malformed_binary_id_is_an_error(self, tools):
-        payload = json.loads(tools.status(binary_id="not-a-sha"))
+        payload = _payload(tools.status(binary_id="not-a-sha"))
         assert "error" in payload
 
     def test_counts_track_marks(self, tools):
         tools.three_functions()
         tools.status(binary_id=tools.binary_id)
         tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
-        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        payload = _payload(tools.status(binary_id=tools.binary_id))
         _assert_contract_invariants(payload)
         assert payload["reviewed"] == 1
         assert payload["reviewed_in_scope"] == 1
@@ -231,7 +265,7 @@ class TestWorklist:
                 _func("b", "140002000"),
             ]
         )
-        payload = json.loads(tools.next(binary_id=tools.binary_id, count=10))
+        payload = _payload(tools.next(binary_id=tools.binary_id, count=10))
         addresses = [f["address"] for f in payload["functions"]]
         assert addresses == ["0x140001000", "0x140002000", "0x140003000"]
 
@@ -239,16 +273,16 @@ class TestWorklist:
         """A client that crashes mid-batch and re-calls must get the same head
         of the queue."""
         tools.three_functions()
-        first = json.loads(tools.next(binary_id=tools.binary_id, count=2))
-        second = json.loads(tools.next(binary_id=tools.binary_id, count=2))
+        first = _payload(tools.next(binary_id=tools.binary_id, count=2))
+        second = _payload(tools.next(binary_id=tools.binary_id, count=2))
         assert first["functions"] == second["functions"]
 
     def test_marking_makes_forward_progress(self, tools):
         tools.three_functions()
-        first = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        first = _payload(tools.next(binary_id=tools.binary_id, count=1))
         head = first["functions"][0]["address"]
         tools.store.mark_reviewed(tools.binary_id, [head], tool="t")
-        second = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        second = _payload(tools.next(binary_id=tools.binary_id, count=1))
         assert second["functions"][0]["address"] != head
 
     def test_terminal_condition(self, tools):
@@ -257,20 +291,20 @@ class TestWorklist:
         tools.store.mark_reviewed(
             tools.binary_id, ["0x140001000", "0x140002000"], tool="t"
         )
-        payload = json.loads(tools.next(binary_id=tools.binary_id, count=10))
+        payload = _payload(tools.next(binary_id=tools.binary_id, count=10))
         assert payload["functions"] == []
         assert payload["remaining_after"] == 0
         assert payload["status"] == "ready"
 
     def test_remaining_after_accounts_for_the_batch(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        payload = _payload(tools.next(binary_id=tools.binary_id, count=1))
         assert payload["returned"] == 1
         assert payload["remaining_after"] == 1
 
     def test_function_record_shape(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        payload = _payload(tools.next(binary_id=tools.binary_id, count=1))
         entry = payload["functions"][0]
         assert set(entry) == {"address", "name", "size", "in_scope", "scope_reason"}
         assert entry["address"].startswith("0x")
@@ -278,8 +312,8 @@ class TestWorklist:
 
     def test_scope_all_includes_excluded_functions(self, tools):
         tools.three_functions()
-        in_scope = json.loads(tools.next(binary_id=tools.binary_id, count=10))
-        every = json.loads(tools.next(binary_id=tools.binary_id, count=10, scope="all"))
+        in_scope = _payload(tools.next(binary_id=tools.binary_id, count=10))
+        every = _payload(tools.next(binary_id=tools.binary_id, count=10, scope="all"))
         assert len(in_scope["functions"]) == 2
         assert len(every["functions"]) == 3
         thunk = next(f for f in every["functions"] if f["address"] == "0x140003000")
@@ -288,25 +322,25 @@ class TestWorklist:
 
     def test_invalid_scope_is_an_error(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.next(binary_id=tools.binary_id, scope="sideways"))
+        payload = _payload(tools.next(binary_id=tools.binary_id, scope="sideways"))
         assert "error" in payload
 
     def test_count_out_of_range_is_an_error(self, tools):
         tools.three_functions()
-        assert "error" in json.loads(tools.next(binary_id=tools.binary_id, count=0))
-        assert "error" in json.loads(tools.next(binary_id=tools.binary_id, count=10_000))
+        assert "error" in _payload(tools.next(binary_id=tools.binary_id, count=0))
+        assert "error" in _payload(tools.next(binary_id=tools.binary_id, count=10_000))
 
 
 class TestIndexTool:
     def test_index_reports_counts(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.index(binary_path=tools.path))
+        payload = _payload(tools.index(binary_path=tools.path))
         assert payload["status"] == "ready"
         _assert_contract_invariants(payload)
         assert payload["total"] == 3
 
     def test_index_without_analysis_is_an_error(self, tools):
-        payload = json.loads(tools.index(binary_path=tools.path))
+        payload = _payload(tools.index(binary_path=tools.path))
         assert "error" in payload
         assert payload["status"] == "not_indexed"
 
@@ -314,14 +348,14 @@ class TestIndexTool:
         tools.three_functions()
         tools.index(binary_path=tools.path)
         tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
-        payload = json.loads(tools.index(binary_path=tools.path, force=True))
+        payload = _payload(tools.index(binary_path=tools.path, force=True))
         assert payload["reviewed"] == 1
 
 
 class TestMarkTool:
     def test_manual_mark_round_trip(self, tools):
         tools.three_functions()
-        payload = json.loads(
+        payload = _payload(
             tools.mark(
                 functions="0x140002000",
                 binary_id=tools.binary_id,
@@ -337,7 +371,7 @@ class TestMarkTool:
     def test_second_mark_is_idempotent(self, tools):
         tools.three_functions()
         tools.mark(functions="0x140002000", binary_id=tools.binary_id)
-        payload = json.loads(
+        payload = _payload(
             tools.mark(functions="0x140002000", binary_id=tools.binary_id)
         )
         assert payload["marked"] == []
@@ -346,19 +380,19 @@ class TestMarkTool:
 
     def test_unknown_address_is_reported_not_counted(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.mark(functions="0xdeadbeef", binary_id=tools.binary_id))
+        payload = _payload(tools.mark(functions="0xdeadbeef", binary_id=tools.binary_id))
         assert payload["unknown"] == ["0xdeadbeef"]
         assert payload["reviewed"] == 0
 
     def test_function_names_are_rejected(self, tools):
         tools.three_functions()
-        payload = json.loads(tools.mark(functions="helper", binary_id=tools.binary_id))
+        payload = _payload(tools.mark(functions="helper", binary_id=tools.binary_id))
         assert "error" in payload
 
     def test_unmark(self, tools):
         tools.three_functions()
         tools.mark(functions="0x140002000", binary_id=tools.binary_id)
-        payload = json.loads(
+        payload = _payload(
             tools.mark(
                 functions="0x140002000", binary_id=tools.binary_id, reviewed=False
             )
@@ -366,7 +400,7 @@ class TestMarkTool:
         assert payload["reviewed"] == 0
 
     def test_mark_before_analysis_is_an_error(self, tools):
-        payload = json.loads(tools.mark(functions="0x140002000", binary_id=tools.binary_id))
+        payload = _payload(tools.mark(functions="0x140002000", binary_id=tools.binary_id))
         assert "error" in payload
 
 

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -1,0 +1,468 @@
+"""
+Tests for the coverage MCP tools (the contract surface).
+
+These are the two calls a consumer binds to, so the assertions here are about
+the wire shape: exact field names, the six invariants, deterministic worklist
+ordering, and the cold-start rule that an unindexed binary reports null counts
+rather than zero.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from src.engines.static.ghidra.coverage_store import SCOPE_VERSION, CoverageStore
+from src.engines.static.ghidra.project_cache import ProjectCache
+from src.tools.coverage_tools import register_coverage_tools
+
+STATUS_FIELDS = {
+    "binary_id",
+    "binary_path",
+    "module_name",
+    "image_base",
+    "total",
+    "in_scope_total",
+    "reviewed",
+    "reviewed_in_scope",
+    "remaining",
+    "remaining_in_scope",
+    "scope_description",
+    "scope_version",
+    "indexed_at",
+    "status",
+}
+
+COUNT_FIELDS = (
+    "total",
+    "in_scope_total",
+    "reviewed",
+    "reviewed_in_scope",
+    "remaining",
+    "remaining_in_scope",
+)
+
+
+def _func(name, address, called=None, *, is_thunk=False, size=64):
+    return {
+        "name": name,
+        "address": address,
+        "size": size,
+        "is_thunk": is_thunk,
+        "is_external": False,
+        "decompile_status": "success",
+        "parameters": [],
+        "pseudocode": "",
+        "jump_tables": [],
+        "called_functions": [{"address": a, "name": ""} for a in (called or [])],
+    }
+
+
+def _context(functions, exports=None):
+    return {
+        "metadata": {
+            "name": "test.sys",
+            "image_base": "140000000",
+            "analysis_depth": "full",
+        },
+        "functions": functions,
+        "exports": exports or [],
+    }
+
+
+class _App:
+    """Minimal FastMCP stand-in that captures the registered callables."""
+
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, *args, **kwargs):
+        def decorate(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorate
+
+
+class _Sessions:
+    _current_binary_path = None
+
+
+@pytest.fixture
+def tools(tmp_path):
+    class Lab:
+        def __init__(self):
+            self.cache = ProjectCache(cache_dir=str(tmp_path))
+            self.store = CoverageStore(self.cache)
+            self.sessions = _Sessions()
+            self.binary = tmp_path / "test.sys"
+            self.binary.write_bytes(b"MZ" + b"\x00" * 512)
+            self.path = str(self.binary)
+            self.binary_id = hashlib.sha256(self.binary.read_bytes()).hexdigest()
+            app = _App()
+            register_coverage_tools(app, self.sessions, self.cache, None)
+            self.status = app.tools["get_coverage_status"]
+            self.next = app.tools["get_next_unreviewed"]
+            self.index = app.tools["coverage_index"]
+            self.mark = app.tools["mark_function_reviewed"]
+
+        def analyze(self, functions, exports=None):
+            self.cache.save_cached(self.path, _context(functions, exports))
+
+        def three_functions(self):
+            self.analyze(
+                [
+                    _func("entry", "140001000", called=["140002000"]),
+                    _func("helper", "140002000", size=100),
+                    _func("thunk", "140003000", is_thunk=True),
+                ],
+                exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+            )
+
+    return Lab()
+
+
+def _assert_contract_invariants(payload):
+    for field in COUNT_FIELDS:
+        value = payload[field]
+        assert isinstance(value, int) and value >= 0, f"{field}={value!r}"
+    assert payload["remaining"] == payload["total"] - payload["reviewed"]
+    assert (
+        payload["remaining_in_scope"]
+        == payload["in_scope_total"] - payload["reviewed_in_scope"]
+    )
+    assert payload["in_scope_total"] <= payload["total"]
+    assert payload["reviewed_in_scope"] <= payload["reviewed"]
+
+
+class TestColdStart:
+    def test_unindexed_binary_returns_null_counts_not_zero(self, tools):
+        """Zero here reads as 'complete' and would terminate a review loop on a
+        binary nobody has looked at -- the exact bug this store exists to fix.
+        """
+        payload = json.loads(tools.status(binary_id="f" * 64))
+        assert payload["status"] == "not_indexed"
+        for field in COUNT_FIELDS:
+            assert payload[field] is None, f"{field} must be null, got {payload[field]!r}"
+
+    def test_unindexed_response_is_still_well_formed(self, tools):
+        payload = json.loads(tools.status(binary_id="f" * 64))
+        assert STATUS_FIELDS <= set(payload)
+        assert payload["binary_id"] == "f" * 64
+        assert payload["scope_version"] == SCOPE_VERSION
+
+    def test_worklist_on_unindexed_binary_is_not_terminal(self, tools):
+        payload = json.loads(tools.next(binary_id="f" * 64))
+        assert payload["status"] == "not_indexed"
+        assert payload["functions"] == []
+        assert payload["remaining_after"] is None
+
+    def test_already_analyzed_binary_indexes_on_first_query(self, tools):
+        """Reporting not_indexed for a binary that is already fully analyzed
+        would strand every previously-cached target."""
+        tools.three_functions()
+        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        assert payload["status"] == "ready"
+        assert payload["total"] == 3
+
+
+class TestStatusShape:
+    def test_field_names_and_invariants(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        assert STATUS_FIELDS <= set(payload)
+        _assert_contract_invariants(payload)
+        assert payload["total"] == 3
+        assert payload["in_scope_total"] == 2
+        assert payload["reviewed"] == 0
+        assert payload["remaining"] == 3
+        assert payload["remaining_in_scope"] == 2
+
+    def test_image_base_is_prefixed_hex(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        assert payload["image_base"] == "0x140000000"
+
+    def test_scope_version_is_reported(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        assert payload["scope_version"] == SCOPE_VERSION
+
+    def test_binary_path_resolution(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.status(binary_path=tools.path))
+        assert payload["binary_id"] == tools.binary_id
+        assert payload["status"] == "ready"
+
+    def test_active_session_binary_is_the_fallback(self, tools):
+        tools.three_functions()
+        tools.sessions._current_binary_path = tools.path
+        payload = json.loads(tools.status())
+        assert payload["binary_id"] == tools.binary_id
+
+    def test_no_resolvable_binary_is_an_error(self, tools):
+        payload = json.loads(tools.status())
+        assert "error" in payload
+
+    def test_malformed_binary_id_is_an_error(self, tools):
+        payload = json.loads(tools.status(binary_id="not-a-sha"))
+        assert "error" in payload
+
+    def test_counts_track_marks(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        payload = json.loads(tools.status(binary_id=tools.binary_id))
+        _assert_contract_invariants(payload)
+        assert payload["reviewed"] == 1
+        assert payload["reviewed_in_scope"] == 1
+        assert payload["remaining"] == 2
+        assert payload["remaining_in_scope"] == 1
+
+
+class TestWorklist:
+    def test_ordering_is_ascending_numeric_address(self, tools):
+        tools.analyze(
+            [
+                _func("c", "140003000"),
+                _func("a", "140001000"),
+                _func("b", "140002000"),
+            ]
+        )
+        payload = json.loads(tools.next(binary_id=tools.binary_id, count=10))
+        addresses = [f["address"] for f in payload["functions"]]
+        assert addresses == ["0x140001000", "0x140002000", "0x140003000"]
+
+    def test_repeated_call_returns_the_same_head(self, tools):
+        """A client that crashes mid-batch and re-calls must get the same head
+        of the queue."""
+        tools.three_functions()
+        first = json.loads(tools.next(binary_id=tools.binary_id, count=2))
+        second = json.loads(tools.next(binary_id=tools.binary_id, count=2))
+        assert first["functions"] == second["functions"]
+
+    def test_marking_makes_forward_progress(self, tools):
+        tools.three_functions()
+        first = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        head = first["functions"][0]["address"]
+        tools.store.mark_reviewed(tools.binary_id, [head], tool="t")
+        second = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        assert second["functions"][0]["address"] != head
+
+    def test_terminal_condition(self, tools):
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(
+            tools.binary_id, ["0x140001000", "0x140002000"], tool="t"
+        )
+        payload = json.loads(tools.next(binary_id=tools.binary_id, count=10))
+        assert payload["functions"] == []
+        assert payload["remaining_after"] == 0
+        assert payload["status"] == "ready"
+
+    def test_remaining_after_accounts_for_the_batch(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        assert payload["returned"] == 1
+        assert payload["remaining_after"] == 1
+
+    def test_function_record_shape(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.next(binary_id=tools.binary_id, count=1))
+        entry = payload["functions"][0]
+        assert set(entry) == {"address", "name", "size", "in_scope", "scope_reason"}
+        assert entry["address"].startswith("0x")
+        assert entry["in_scope"] is True
+
+    def test_scope_all_includes_excluded_functions(self, tools):
+        tools.three_functions()
+        in_scope = json.loads(tools.next(binary_id=tools.binary_id, count=10))
+        every = json.loads(tools.next(binary_id=tools.binary_id, count=10, scope="all"))
+        assert len(in_scope["functions"]) == 2
+        assert len(every["functions"]) == 3
+        thunk = next(f for f in every["functions"] if f["address"] == "0x140003000")
+        assert thunk["in_scope"] is False
+        assert thunk["scope_reason"] == "excluded:thunk"
+
+    def test_invalid_scope_is_an_error(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.next(binary_id=tools.binary_id, scope="sideways"))
+        assert "error" in payload
+
+    def test_count_out_of_range_is_an_error(self, tools):
+        tools.three_functions()
+        assert "error" in json.loads(tools.next(binary_id=tools.binary_id, count=0))
+        assert "error" in json.loads(tools.next(binary_id=tools.binary_id, count=10_000))
+
+
+class TestIndexTool:
+    def test_index_reports_counts(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.index(binary_path=tools.path))
+        assert payload["status"] == "ready"
+        _assert_contract_invariants(payload)
+        assert payload["total"] == 3
+
+    def test_index_without_analysis_is_an_error(self, tools):
+        payload = json.loads(tools.index(binary_path=tools.path))
+        assert "error" in payload
+        assert payload["status"] == "not_indexed"
+
+    def test_force_rebuild_keeps_marks(self, tools):
+        tools.three_functions()
+        tools.index(binary_path=tools.path)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        payload = json.loads(tools.index(binary_path=tools.path, force=True))
+        assert payload["reviewed"] == 1
+
+
+class TestMarkTool:
+    def test_manual_mark_round_trip(self, tools):
+        tools.three_functions()
+        payload = json.loads(
+            tools.mark(
+                functions="0x140002000",
+                binary_id=tools.binary_id,
+                note="unchecked length",
+            )
+        )
+        assert payload["marked"] == ["0x140002000"]
+        assert payload["reviewed"] == 1
+        _assert_contract_invariants(payload)
+        entry = tools.store.read(tools.binary_id)["functions"]["0x140002000"]
+        assert entry["findings_note"] == "unchecked length"
+
+    def test_second_mark_is_idempotent(self, tools):
+        tools.three_functions()
+        tools.mark(functions="0x140002000", binary_id=tools.binary_id)
+        payload = json.loads(
+            tools.mark(functions="0x140002000", binary_id=tools.binary_id)
+        )
+        assert payload["marked"] == []
+        assert payload["already"] == ["0x140002000"]
+        assert payload["reviewed"] == 1
+
+    def test_unknown_address_is_reported_not_counted(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.mark(functions="0xdeadbeef", binary_id=tools.binary_id))
+        assert payload["unknown"] == ["0xdeadbeef"]
+        assert payload["reviewed"] == 0
+
+    def test_function_names_are_rejected(self, tools):
+        tools.three_functions()
+        payload = json.loads(tools.mark(functions="helper", binary_id=tools.binary_id))
+        assert "error" in payload
+
+    def test_unmark(self, tools):
+        tools.three_functions()
+        tools.mark(functions="0x140002000", binary_id=tools.binary_id)
+        payload = json.loads(
+            tools.mark(
+                functions="0x140002000", binary_id=tools.binary_id, reviewed=False
+            )
+        )
+        assert payload["reviewed"] == 0
+
+    def test_mark_before_analysis_is_an_error(self, tools):
+        payload = json.loads(tools.mark(functions="0x140002000", binary_id=tools.binary_id))
+        assert "error" in payload
+
+
+class TestAutoMarkingSet:
+    """Locks down which tools advance the denominator as a side effect.
+
+    Over-marking is the dangerous direction: a tool that "reviews" functions
+    nobody read manufactures the false completion this store exists to prevent.
+    The consumer restates this set in its operator docs, so it must not drift
+    silently.
+    """
+
+    @pytest.fixture
+    def analysis_tools(self, tools):
+        from src.tools.function_hash_tools import register_function_hash_tools
+        from src.tools.review_tools import register_review_tools
+
+        tools.analyze(
+            [
+                _func("entry", "140001000", called=["140002000"]),
+                {
+                    **_func("helper", "140002000"),
+                    "pseudocode": "void helper(int *p){ memcpy(p, param_1, 8); }",
+                    "parameters": [{"name": "param_1", "datatype": "char *"}],
+                    "signature": "void helper(char *param_1)",
+                    "basic_blocks": [],
+                    "local_variables": [],
+                },
+            ],
+            exports=[{"address": "140001000", "name": "entry", "type": "Function"}],
+        )
+        app = _App()
+        register_function_hash_tools(app, tools.sessions, tools.cache, None)
+        register_review_tools(app, tools.sessions, tools.cache, None, None)
+        return tools, app.tools
+
+    def _reviewed(self, tools):
+        record = tools.store.read(tools.binary_id)
+        if record is None:
+            return set()
+        return {a for a, e in record["functions"].items() if e["reviewed"]}
+
+    def test_batch_decompile_marks(self, analysis_tools):
+        tools, api = analysis_tools
+        api["batch_decompile"](binary_path=tools.path, functions="0x140002000")
+        assert self._reviewed(tools) == {"0x140002000"}
+
+    def test_batch_decompile_does_not_mark_what_it_could_not_decompile(
+        self, analysis_tools
+    ):
+        tools, api = analysis_tools
+        # 0x140001000 has no pseudocode in this fixture.
+        api["batch_decompile"](binary_path=tools.path, functions="0x140001000")
+        assert self._reviewed(tools) == set()
+
+    def test_get_review_package_marks(self, analysis_tools):
+        tools, api = analysis_tools
+        api["get_review_package"](
+            binary_path=tools.path, function_name_or_address="0x140002000"
+        )
+        assert self._reviewed(tools) == {"0x140002000"}
+
+    def test_get_param_sinks_marks(self, analysis_tools):
+        tools, api = analysis_tools
+        api["get_param_sinks"](binary_path=tools.path, function="0x140002000")
+        assert self._reviewed(tools) == {"0x140002000"}
+
+    def test_get_function_callers_does_not_mark(self, analysis_tools):
+        tools, api = analysis_tools
+        api["get_function_callers"](
+            binary_path=tools.path, function_name_or_address="0x140002000"
+        )
+        assert self._reviewed(tools) == set()
+
+    def test_scan_pseudocode_does_not_mark(self, analysis_tools):
+        """A whole-binary regex sweep is not a review of every function it
+        touched."""
+        tools, api = analysis_tools
+        api["scan_pseudocode"](binary_path=tools.path)
+        assert self._reviewed(tools) == set()
+
+    def test_analyze_function_completeness_does_not_mark(self, analysis_tools):
+        tools, api = analysis_tools
+        api["analyze_function_completeness"](
+            binary_path=tools.path, function_name_or_address="0x140002000"
+        )
+        assert self._reviewed(tools) == set()
+
+    def test_marking_is_idempotent_across_repeated_reads(self, analysis_tools):
+        tools, api = analysis_tools
+        api["batch_decompile"](binary_path=tools.path, functions="0x140002000")
+        first = tools.store.read(tools.binary_id)["functions"]["0x140002000"]
+        api["get_review_package"](
+            binary_path=tools.path, function_name_or_address="0x140002000"
+        )
+        second = tools.store.read(tools.binary_id)["functions"]["0x140002000"]
+        assert second["reviewed_at"] == first["reviewed_at"]
+        assert second["reviewed_by"] == "batch_decompile"
+        assert tools.store.counts(tools.store.read(tools.binary_id))["reviewed"] == 1

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -470,6 +470,65 @@ class TestResetTool:
         assert payload["total"] == 3
         assert payload["reviewed"] == 0
 
+    def test_drop_index_is_refused_when_nothing_can_rebuild_the_record(self, tools):
+        """`ProjectCache.invalidate` evicts the analysis and deliberately spares
+        the coverage side-car, so `stale` is a routine state -- and it is the
+        state where the record is the ONLY surviving account of what was
+        reviewed. Dropping it there is unrecoverable, and reset_coverage is
+        reached exactly when the ledger is already known-bad.
+        """
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        (tools.cache.cache_dir / f"{tools.binary_id}.json.gz").unlink()
+
+        payload = _payload(tools.reset(binary_id=tools.binary_id, drop_index=True))
+
+        assert "error" in payload
+        assert payload["dropped"] is False
+        assert payload["cleared"] == 0
+        # The refusal has to leave the record intact, or it is not a refusal.
+        record = tools.store.read(tools.binary_id)
+        assert record is not None
+        assert record["functions"]["0x140002000"]["reviewed"] is True
+
+    def test_refused_drop_still_leaves_clearing_marks_available(self, tools):
+        """The refusal must not strand the operator: the safe half of the
+        operation still works."""
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        tools.store.mark_reviewed(tools.binary_id, ["0x140002000"], tool="t")
+        (tools.cache.cache_dir / f"{tools.binary_id}.json.gz").unlink()
+        tools.reset(binary_id=tools.binary_id, drop_index=True)
+
+        payload = _payload(tools.reset(binary_id=tools.binary_id))
+        assert payload["cleared"] == 1
+        assert payload["reviewed"] == 0
+        assert payload["total"] == 3  # denominator survives
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            # refused drop, no record at all, and the ordinary success path
+            lambda t: t.reset(binary_id=t.binary_id, drop_index=True),
+            lambda t: t.reset(binary_id="f" * 64),
+            lambda t: t.reset(binary_id=t.binary_id),
+        ],
+    )
+    def test_every_reset_payload_carries_all_six_count_keys(self, tools, call):
+        """An omitted key is not a null. A consumer reading
+        `payload.get("total", 0)` off a response that dropped the key lands on
+        0, and 0 reads as "complete" -- the same false completion the
+        null-not-zero rule exists to prevent, reached through the client's
+        default instead of the server's value.
+        """
+        tools.three_functions()
+        tools.status(binary_id=tools.binary_id)
+        (tools.cache.cache_dir / f"{tools.binary_id}.json.gz").unlink()
+        payload = _payload(call(tools))
+        for field in COUNT_FIELDS:
+            assert field in payload, f"{field} missing from {sorted(payload)}"
+
     def test_reset_without_a_record_is_an_error_not_a_silent_success(self, tools):
         tools.three_functions()
         payload = _payload(tools.reset(binary_id=tools.binary_id))
@@ -501,6 +560,51 @@ class TestResetTool:
         after = _payload(tools.next(binary_id=tools.binary_id))
         assert len(after["functions"]) == 2
         assert after["remaining_after"] == 0
+
+
+class TestUnparseableAddresses:
+    """A binary whose addresses `canon_addr` rejects must not report a finished
+    worklist. `ready` with six zeros is the documented terminal condition."""
+
+    def test_all_unparseable_reports_not_indexed_with_null_counts(self, tools):
+        tools.analyze(
+            [_func("a", "EXTERNAL:1"), _func("b", "EXTERNAL:2"), _func("c", "EXTERNAL:3")]
+        )
+        payload = _payload(tools.status(binary_id=tools.binary_id))
+        assert payload["status"] == "not_indexed"
+        for field in COUNT_FIELDS:
+            assert payload[field] is None, f"{field}={payload[field]!r}"
+
+    def test_all_unparseable_worklist_is_not_terminal(self, tools):
+        tools.analyze([_func("a", "EXTERNAL:1"), _func("b", "EXTERNAL:2")])
+        payload = _payload(tools.next(binary_id=tools.binary_id))
+        assert payload["status"] == "not_indexed"
+        assert payload["functions"] == []
+        assert payload["remaining_after"] is None
+
+    def test_partial_drop_is_visible_in_the_status_payload(self, tools):
+        """`total` still under-counts here -- the point is that the consumer can
+        see it rather than having to infer it."""
+        tools.analyze(
+            [
+                _func("a", "140001000"),
+                _func("b", "140002000"),
+                _func("x", "EXTERNAL:1"),
+            ]
+        )
+        payload = _payload(tools.status(binary_id=tools.binary_id))
+        assert payload["status"] == "ready"
+        assert payload["total"] == 2
+        assert payload["dropped_address_count"] == 1
+
+    def test_dropped_address_count_is_present_on_a_clean_binary(self, tools):
+        tools.three_functions()
+        payload = _payload(tools.status(binary_id=tools.binary_id))
+        assert payload["dropped_address_count"] == 0
+
+    def test_dropped_address_count_is_null_when_not_indexed(self, tools):
+        payload = _payload(tools.status(binary_id="f" * 64))
+        assert payload["dropped_address_count"] is None
 
 
 class TestAutoMarkingSet:
@@ -578,6 +682,26 @@ class TestAutoMarkingSet:
         )
         # The package is still returned -- callers/blocks stay useful.
         assert out and "0x140001000" in out.lower() or out
+        assert self._reviewed(tools) == set()
+
+    def test_comment_only_body_does_not_mark(self, analysis_tools):
+        """Ghidra emits a banner comment instead of code when it declines to
+        decompile. Showing a remark about a function is not showing the
+        function, so it must not advance the denominator."""
+        tools, api = analysis_tools
+        record = tools.cache.get_cached(tools.path)
+        for func in record["functions"]:
+            if func["address"] == "140002000":
+                func["pseudocode"] = (
+                    "/* WARNING: Globals starting with '_' overlap smaller symbols */\n"
+                )
+        tools.cache.save_cached(tools.path, record)
+
+        api["batch_decompile"](binary_path=tools.path, functions="0x140002000")
+        api["get_review_package"](
+            binary_path=tools.path, function_name_or_address="0x140002000"
+        )
+        api["get_param_sinks"](binary_path=tools.path, function="0x140002000")
         assert self._reviewed(tools) == set()
 
     def test_get_param_sinks_marks(self, analysis_tools):

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -562,6 +562,24 @@ class TestAutoMarkingSet:
         )
         assert self._reviewed(tools) == {"0x140002000"}
 
+    def test_get_review_package_does_not_mark_without_pseudocode(
+        self, analysis_tools
+    ):
+        """A package with no body reviewed nothing.
+
+        The negative twin of test_get_review_package_marks. Without this,
+        driving the documented loop against a structural-depth cache reaches
+        remaining==0 having shown zero bytes of pseudocode.
+        """
+        tools, api = analysis_tools
+        # 0x140001000 has no pseudocode in this fixture.
+        out = api["get_review_package"](
+            binary_path=tools.path, function_name_or_address="0x140001000"
+        )
+        # The package is still returned -- callers/blocks stay useful.
+        assert out and "0x140001000" in out.lower() or out
+        assert self._reviewed(tools) == set()
+
     def test_get_param_sinks_marks(self, analysis_tools):
         tools, api = analysis_tools
         api["get_param_sinks"](binary_path=tools.path, function="0x140002000")


### PR DESCRIPTION
Makes binary-mcp the single source of truth for per-binary review coverage, so an autonomous client can ask how much of a binary is left rather than guessing.

Consumer side: **Sarks0/vr-lab#67**, which mirrors these counts and blocks campaign closure on them. Review together — the two were built against a pinned contract and cross-checked each other.

## Why

Clients had no way to tell how much of a binary remained unaudited. An agent that reviewed 40 of 400 functions had the same internal state as one that reviewed 400 of 400, and reported the same sentence. The denominator has to come from something that counts.

## What landed

**Coverage store** — `<sha256>.coverage.json` side-car in the existing cache root, alongside `<sha>.json.gz` and `<sha>.funcidx.json`. Deliberately *not* SQLite: the server already persists hash-keyed state, so this inherits the cache's eviction, backup, and `clean_cache` story rather than introducing a parallel one.

**Key scheme** — binary identity is the sha256 hexdigest already computed by `project_cache._get_binary_hash`. Function identity is the canonical lowercase unpadded hex VA at the static image base (`0x140006d8c`). Both were chosen to match what consumers already validate, so no new identity scheme enters the system.

**Tools**

| Tool | Purpose |
|---|---|
| `get_coverage_status` | the denominator: total / in_scope_total / reviewed / remaining (+ in-scope variants) |
| `get_next_unreviewed(count, scope)` | next batch of unreviewed addresses, deterministic ascending order so a resuming client makes progress |
| `coverage_index` | explicit index/re-index |
| `mark_function_reviewed` | manual mark (auto-marking is the default path) |
| `reset_coverage(drop_index=False)` | the undo — see below |

**Auto-mark** — per-function decompile/analyze tools mark reviewed as a side effect, idempotently. Whole-binary enumeration and name/address-only listings deliberately do *not* mark: seeing a function in a list is not reviewing it.

**Scope** — forward BFS over the cached `called_functions` graph from exports, IOCTL dispatch entries, and address-taken roots with no direct caller; minus thunks/externals/FID library hits. No Ghidra re-run required. Indirect calls are invisible to a forward walk, so scope is **deliberately over-approximated** — the denominator never shrinks on a guess, and excluded functions stay retrievable via `scope="all"`.

## Two things worth reviewer attention

**Cold start returns nulls, not zeros.** An unindexed binary returns all six counts as `null` with `status: "not_indexed"`. Zero would read as "complete" and terminate a client's loop instantly — precisely the bug this change exists to prevent. `status` is `ready | not_indexed | indexing | stale`.

**`remaining_in_scope == 0` does not mean the binary is done.** It means the in-scope worklist is done. Full closure consults `remaining`.

## Fixed in flight

- **Response envelope** (`7c881e3`): returning a JSON string made FastMCP wrap it as `structuredContent = {"result": "<json as a string>"}`, so a client peeling one envelope layer landed on a string, not an object. All coverage tools now return the object directly — `structuredContent`, `.data`, and `content[0].text` agree. Regression-tested.
- **BFS layering**: the export layer's walk was claiming dispatchers as plain callees. Counts were unaffected; only the provenance breakdown changed (`5 dispatch entries` → `8`).
- **`reset_coverage`** (`15c96bc`): added after a demo script bulk-marked 248 functions on a real binary, leaving it recorded as fully reviewed by nobody with no way to undo it. Verification now runs against a scratch cache fixture that repoints `BINARY_CACHE_DIR` and aborts if it escapes.

## Measurement note for consumers

On dynamically-linked Microsoft production binaries, `in_scope_total ≈ total`. Exclusion peaks at 3.1% (bindflt) and *falls* with size — chakra 0.9%, http.sys 0.5%, securekernel 0.3%. The CRT arrives as imports, not analyzed function bodies, so there is little library mass to exclude and the second denominator does little work on this corpus. Where scope does earn its place is `excluded:unreachable` on large JS engines (chakra 148, jscript9 59).

The `excluded:fid_library` arm is implemented and unit-tested but has **zero production exercise** — `enable_fid=True` is off by default and 0 of 225,357 cached functions carry a `fid_match`. Not dead code, but untrusted until it fires once for real.

## Compatibility & tests

Additive throughout; existing tools are unchanged for clients that ignore coverage. Full suite green, `ruff` clean.

https://claude.ai/code/session_01EoTrqpCr3BxU7eTYtEXTY9
